### PR TITLE
Add more helpful MissingDependencyError message

### DIFF
--- a/lib/sow/dependency.rb
+++ b/lib/sow/dependency.rb
@@ -9,8 +9,6 @@ module Sow
       collection.get(klass, sow_id) || new(klass, sow_id)
     end
 
-    private
-
     def initialize(klass, sow_id)
       @klass = klass
       @sow_id = sow_id
@@ -18,6 +16,14 @@ module Sow
 
       self.class.collection.set(klass, sow_id, self)
     end
+
+    def sow_record_reference
+      "sow_record(#{klass}, #{sow_id})"
+    end
+
+    private
+
+    attr_reader :klass, :sow_id
 
     def self.to_klass(klass)
       if klass.is_a?(String)

--- a/spec/fixtures/seeds/development/posts_missing_dependency.yml
+++ b/spec/fixtures/seeds/development/posts_missing_dependency.yml
@@ -1,0 +1,7 @@
+# posts_missing_dependency.yml
+
+records:
+  - sow_id: 1
+    title: 'Yaml title'
+    content: 'Yaml content'
+    comment_id: "<%= sow_record(Comment, 42).id %>" # This sow record does not exist.

--- a/spec/sow_spec.rb
+++ b/spec/sow_spec.rb
@@ -75,6 +75,23 @@ describe "Seeding an application" do
     end
   end
 
+  context "with a relationship to an undefined record" do
+    around do |example|
+      load_seeds('posts.yml', 'posts_missing_dependency.yml', &example)
+    end
+
+    it "raises a helpful error message" do
+      expect {
+        sow [
+          [Post, :data => { :source => open('spec/fixtures/seeds/development/posts_missing_dependency.yml') }]
+        ]
+      }.to raise_error(
+        Sow::DependencySorter::MissingDependencyError,
+        "Undefined reference to 'sow_record(Comment, 42)'"
+      )
+    end
+  end
+
   context "with multiple files for a class" do
     around do |example|
       load_seeds('posts.yml', 'legacy_posts.yml', &example)


### PR DESCRIPTION
Previously when you had a reference to a non-existant sow_record (for
instance if you had only 2 Post records defined in posts.yml and had a
reference to 'sow_record(Post, 6)' somewhere within comments.yml) an
exception was raised that did not help locate the missing dependency.
Thus ensued an unpleasant treasure hunt through all of your seed record files.

This commit adds a better error message to MissingDependencyErrors, so
if you reference 'sow_record(Post, 6)', and it doesn't exist, you get an
error saying that sow_record(Post, 6) doesn't exist.
