### PR TITLE
Not erroring when a reference to an unsaved record is made

### DIFF
--- a/lib/sprig/helpers.rb
+++ b/lib/sprig/helpers.rb
@@ -1,5 +1,12 @@
 module Sprig
   module Helpers
+
+    class NullRecord
+      def method_missing(*)
+        nil
+      end
+    end
+
     def seed_directory
       Sprig.configuration.directory
     end
@@ -16,10 +23,17 @@ module Sprig
 
     def sprig_record(klass, seed_id)
       SprigRecordStore.instance.get(klass, seed_id)
+    rescue SprigRecordStore::RecordNotFoundError => error
+      sprig_record_not_found(error)
     end
 
     def sprig_file(relative_path)
       File.new(seed_directory.join('files', relative_path))
+    end
+
+    def sprig_record_not_found(error)
+      puts "\e[#{31}m#{error}\e[0m"
+      return NullRecord.new
     end
   end
 end

--- a/lib/sprig/sprig_logger.rb
+++ b/lib/sprig/sprig_logger.rb
@@ -18,6 +18,7 @@ module Sprig
       message = seed.error_log_text
       @errors << seed.record
       puts red(message)
+      puts red("#{seed.record}\n#{seed.record.errors.messages}\n")
       @error_count += 1
     end
 

--- a/spec/fixtures/seeds/test/posts_missing_record.yml
+++ b/spec/fixtures/seeds/test/posts_missing_record.yml
@@ -4,4 +4,4 @@ records:
   - sprig_id: 1
     title: 'Yaml title'
     content: 'Yaml content'
-    user_id: "<%= sprig_record(User, 1).id %>" # This sprig record does not exist.
+    user_id: "<%= sprig_record(User, 1).id %>" # This sprig record did not save.

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -112,12 +112,12 @@ describe "Seeding an application" do
     end
   end
 
-  context "with a relationship to a missing record" do
+  context "with a relationship to a record that didn't save" do
     around do |example|
       load_seeds('invalid_users.yml', 'posts_missing_record.yml', &example)
     end
 
-    it "raises a helpful error message" do
+    it "does not error, but carries on with the seeding" do
       expect {
         sprig [
           {
@@ -129,10 +129,7 @@ describe "Seeding an application" do
             :source => open('spec/fixtures/seeds/test/invalid_users.yml')
           }
         ]
-      }.to raise_error(
-        Sprig::SprigRecordStore::RecordNotFoundError,
-        "Record for class User and sprig_id 1 could not be found."
-      )
+      }.to_not raise_error
     end
   end
 


### PR DESCRIPTION
Instead of raising a custom error, puts out the message about the missing reference (in red) and carry on. I believe this feature was waiting on @ltk to refactor the existing Logger, but I think this would be production ready prior to that.
