### PR TITLE
[#17] Updates logger text to display 'updated' on existing records. 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sprig (0.1.1)
+    sprig (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/sprig/seed/entry.rb
+++ b/lib/sprig/seed/entry.rb
@@ -27,6 +27,8 @@ module Sprig
       end
 
       def save_record
+        @persisted = record.persisted?
+
         record.save
       end
 
@@ -35,7 +37,11 @@ module Sprig
       end
 
       def success_log_text
-        "#{klass.name} with sprig_id #{sprig_id} successfully saved."
+        "#{klass.name} with sprig_id #{sprig_id} successfully #{success_log_status_text}."
+      end
+
+      def success_log_status_text
+        @persisted ? "updated" : "saved"
       end
 
       def error_log_text

--- a/lib/sprig/seed/entry.rb
+++ b/lib/sprig/seed/entry.rb
@@ -27,8 +27,6 @@ module Sprig
       end
 
       def save_record
-        @persisted = record.persisted?
-
         record.save
       end
 
@@ -41,7 +39,7 @@ module Sprig
       end
 
       def success_log_status_text
-        @persisted ? "updated" : "saved"
+        record.existing? ? "updated" : "saved"
       end
 
       def error_log_text

--- a/lib/sprig/seed/record.rb
+++ b/lib/sprig/seed/record.rb
@@ -11,9 +11,10 @@ module Sprig
       end
 
       def initialize(klass, attributes, orm_record = nil)
-        @klass = klass
+        @klass      = klass
         @attributes = attributes
         @orm_record = orm_record || klass.new
+        @existing   = @orm_record.persisted?
       end
 
       def save
@@ -21,8 +22,8 @@ module Sprig
         orm_record.save
       end
 
-      def persisted?
-        orm_record.persisted?
+      def existing?
+        @existing
       end
 
       private

--- a/lib/sprig/seed/record.rb
+++ b/lib/sprig/seed/record.rb
@@ -21,6 +21,10 @@ module Sprig
         orm_record.save
       end
 
+      def persisted?
+        orm_record.persisted?
+      end
+
       private
 
       attr_reader :attributes, :klass

--- a/spec/lib/sprig/seed/entry_spec.rb
+++ b/spec/lib/sprig/seed/entry_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Sprig::Seed::Entry do
+  describe ".success_log_text" do
+    context "on a new record" do
+      it "indicates the record was 'saved'" do
+        subject = described_class.new(Post, { title: "Hello World!", content: "Stuff", sprig_id: 1 }, {})
+        subject.save_record
+
+        subject.success_log_text.should == "Post with sprig_id 1 successfully saved."
+      end
+    end
+
+    context "on an existing record" do
+      let!(:existing) do
+        Post.create(
+          :title      => "Existing title",
+          :content    => "Existing content",
+          :published  => false
+        )
+      end
+
+      it "indicates the record was 'updated'" do
+        subject = described_class.new(Post, { title: "Existing title", content: "Existing content", sprig_id: 1 }, { find_existing_by: [:title] })
+        subject.save_record
+
+        subject.success_log_text.should == "Post with sprig_id 1 successfully updated."
+      end
+    end
+  end
+end

--- a/spec/lib/sprig/seed/record_spec.rb
+++ b/spec/lib/sprig/seed/record_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Sprig::Seed::Record do
+  describe ".persisted?" do
+    let!(:existing) do
+      Post.create(
+        :title      => "Existing title",
+        :content    => "Existing content",
+        :published  => false
+      )
+    end
+
+    it "returns true if the record has already been saved to the database" do
+      subject = described_class.new_or_existing(Post, { title: "Existing title" }, { title: "Existing title" })
+
+      subject.persisted?.should == true
+    end
+
+    it "returns false if the record is new" do
+      subject = described_class.new_or_existing(Post, { title: "New title" }, { title: "New title" })
+
+      subject.persisted?.should == false
+    end
+  end
+end

--- a/spec/lib/sprig/seed/record_spec.rb
+++ b/spec/lib/sprig/seed/record_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Sprig::Seed::Record do
-  describe ".persisted?" do
+  describe ".existing?" do
     let!(:existing) do
       Post.create(
         :title      => "Existing title",
@@ -13,13 +13,13 @@ describe Sprig::Seed::Record do
     it "returns true if the record has already been saved to the database" do
       subject = described_class.new_or_existing(Post, { title: "Existing title" }, { title: "Existing title" })
 
-      subject.persisted?.should == true
+      subject.existing?.should == true
     end
 
     it "returns false if the record is new" do
       subject = described_class.new_or_existing(Post, { title: "New title" }, { title: "New title" })
 
-      subject.persisted?.should == false
+      subject.existing?.should == false
     end
   end
 end


### PR DESCRIPTION
Previously the only indication to the user was that all records were 'saved'.

This adds functionality to indicate when a record already existing by saying it was 'updated'.

I'm not sure on the placement and use of the ivar `@persisted` in the Sprig::Seed::Entry class. Open to suggestions on how this can be improved.
