### PR TITLE
Allow additional configuration options and enhanced control when using `reap`

### DIFF
--- a/lib/sprig/harvest.rb
+++ b/lib/sprig/harvest.rb
@@ -1,32 +1,46 @@
 module Sprig
   module Harvest
     autoload :Configuration, 'sprig/harvest/configuration'
+    autoload :ModelConfig,   'sprig/harvest/model_config'
     autoload :Model,         'sprig/harvest/model'
     autoload :Record,        'sprig/harvest/record'
     autoload :SeedFile,      'sprig/harvest/seed_file'
 
     class << self
       def reap(options = {})
-        configure do |config|
-          config.env     = options[:env]    || options['ENV']
-          config.classes = options[:models] || options['MODELS']
+        file_path = options[:file] || options['FILE']
+
+        if file_path && File.exists?(file_path)
+          load(file_path)
+        else
+          configure do |config|
+            config.env           = options[:env]           || options['ENV']
+            config.classes       = options[:models]        || options['MODELS']
+            config.limit         = options[:limit]         || options['LIMIT']
+            config.ignored_attrs = options[:ignored_attrs] || options['IGNORED_ATTRS']
+          end
         end
 
         Model.all.each { |model| SeedFile.new(model).write }
+      end
+
+      def configure
+        yield configuration
       end
 
       private
 
       cattr_reader :configuration
 
-      delegate :env, :classes, to: :configuration
+      delegate :env,
+               :classes,
+               :limit,
+               :ignored_attrs,
+               :model_configurations,
+               :to => :configuration
 
       def configuration
         @@configuration ||= Configuration.new
-      end
-
-      def configure
-        yield configuration
       end
     end
   end

--- a/lib/sprig/harvest/model_config.rb
+++ b/lib/sprig/harvest/model_config.rb
@@ -1,0 +1,47 @@
+module Sprig
+  module Harvest
+    class ModelConfig
+      attr_reader :klass
+
+      def initialize(klass, config = {})
+        self.klass = klass
+
+        @config = config
+      end
+
+      def klass=(given_class)
+        unless Sprig::Harvest::Configuration::VALID_CLASSES.include? given_class
+          raise ArgumentError, "Cannot create a seed file for #{given_class} because it is not a subclass of ActiveRecord::Base."
+        end
+
+        @klass = given_class
+      end
+
+      def collection
+        @collection ||= config.fetch(:collection, klass.all)
+      end
+
+      def limit
+        @limit ||= config.fetch(:limit, Sprig::Harvest.limit)
+      end
+
+      def ignored_attrs
+        @ignored_attrs ||= (Array(config[:ignored_attrs]).map(&:to_s) + Sprig::Harvest.ignored_attrs).uniq
+      end
+
+      def attributes
+        @attributes ||= klass.column_names - ignored_attrs
+      end
+
+      def dependencies
+        @dependencies ||= klass.reflect_on_all_associations(:belongs_to).map do |association|
+          association.name.to_s.classify.constantize
+        end
+      end
+
+      private
+
+      attr_reader :config
+    end
+  end
+end

--- a/spec/fixtures/db/seeds/reap_config.rb
+++ b/spec/fixtures/db/seeds/reap_config.rb
@@ -1,0 +1,21 @@
+Sprig::Harvest.configure do |config|
+  config.env           = 'dreamland'
+  config.limit         = 30
+  config.ignored_attrs = [:created_at, :updated_at]
+
+  config.models = [
+    {
+      :class         => User,
+      :collection    => User.where(last_name: 'Janglez'),
+      :limit         => 10,
+      :ignored_attrs => :type
+    },
+
+    {
+      :class      => Post,
+      :limit      => 20
+    },
+
+    Comment
+  ]
+end

--- a/spec/lib/sprig/harvest/configuration_spec.rb
+++ b/spec/lib/sprig/harvest/configuration_spec.rb
@@ -53,46 +53,136 @@ describe Sprig::Harvest::Configuration do
 
   describe "#classes=" do
     context "when given nil" do
-      it "does not set classes to nil" do
-        subject.classes = nil
+      before { subject.classes = nil }
 
-        subject.classes.should_not == nil
-      end
+      its(:classes) { should_not == nil }
     end
 
     context "when given an array of classes" do
-      context "where one or more classes are not subclasses of ActiveRecord::Base" do
-        it "raises an error" do
-          expect {
-            subject.classes = [Comment, Sprig::Harvest::Model]
-          }.to raise_error ArgumentError, 'Cannot create a seed file for Sprig::Harvest::Model because it is not a subclass of ActiveRecord::Base.'
-        end
-      end
+      before { subject.classes = [Comment, Post] }
 
-      context "where all classes are subclasses of ActiveRecord::Base" do
-        it "sets classes to the given input" do
-          subject.classes = [Comment, Post]
-
-          subject.classes.should == [Comment, Post]
-        end
-      end
+      its(:classes) { should == [Comment, Post] }
     end
 
     context "when given a string" do
-      context "where one or more classes are not subclasses of ActiveRecord::Base" do
+      before { subject.classes = ' comment, post' }
+
+      its(:classes) {should == [Comment, Post] }
+    end
+  end
+
+  describe "#limit=" do
+    context "given a string" do
+      context "that results in a 0" do
         it "raises an error" do
           expect {
-            subject.classes = 'Sprig::Harvest::Model'
-          }.to raise_error ArgumentError, 'Cannot create a seed file for Sprig::Harvest::Model because it is not a subclass of ActiveRecord::Base.'
+            subject.limit = 'wow'
+          }.to raise_error ArgumentError, 'Limit can only be set to an integer above 0 (received 0)'
         end
       end
 
-      context "where all classes are subclasses of ActiveRecord::Base" do
-        it "sets classes to the parsed input" do
-          subject.classes = ' comment, post'
+      context "that results in a non-0 integer" do
+        before { subject.limit = ' 25' }
 
-          subject.classes.should == [Comment, Post]
-        end
+        its(:limit) { should == 25 }
+      end
+    end
+
+    context "given an integer" do
+      before { subject.limit = 10 }
+
+      its(:limit) { should == 10 }
+    end
+  end
+
+  describe "#ignored_attrs=" do
+    context "when given nil" do
+      before { subject.classes = nil }
+
+      its(:ignored_attrs) { should_not == nil }
+    end
+
+    context "when given an array of ignored_attrs" do
+      before { subject.ignored_attrs = [:shaka, ' laka '] }
+
+      its(:ignored_attrs) { should == ['shaka', 'laka'] }
+    end
+
+    context "when given a string" do
+      before { subject.ignored_attrs = ' shaka, laka' }
+
+      its(:ignored_attrs) { should == ['shaka', 'laka'] }
+    end
+  end
+
+  describe "#ignored_attrs" do
+    context "on a fresh configuration" do
+      its(:ignored_attrs) { should == [] }
+    end
+  end
+
+  describe "#models=" do
+    context "given an array containing a valid class" do
+      let(:config) { double('Sprig::Harvest::ModelConfig') }
+
+      it "creates a new model config and stores it in model configurations" do
+        Sprig::Harvest::ModelConfig.stub(:new).with(User).and_return(config)
+
+        subject.models = [User]
+
+        subject.model_configurations.should == [config]
+      end
+    end
+    
+    context "given an array containain a hash" do
+      let(:config) { double('Sprig::Harvest::ModelConfig') }
+
+
+      let(:parsed_hash) do
+        {
+          :limit         => 5,
+          :ignored_attrs => [:created_at, :updated_at]
+        }
+      end
+
+      let(:hash) do
+        { :class => User }.merge(parsed_hash)
+      end
+
+      it "creates a new model config and stores it in model configurations" do
+        Sprig::Harvest::ModelConfig.stub(:new).with(User, parsed_hash).and_return(config)
+
+        subject.models = [hash]
+
+        subject.model_configurations.should == [config]
+      end
+    end
+  end
+
+  describe "#model_configurations" do
+    context "on a fresh config" do
+      it "contains an array of model configs for each ActiveRecord::Base subclass" do
+        configs = subject.model_configurations
+        klasses = configs.map(&:klass)
+
+        configs.size.should == ActiveRecord::Base.subclasses.size
+
+        ActiveRecord::Base.subclasses.each { |klass| klasses.include?(klass).should == true }
+      end
+    end
+
+    context "when classes have been set" do
+      before do
+        subject.classes = [User, Post]
+      end
+
+      it "contains an array of model configs for each of the previous set classes" do
+        configs = subject.model_configurations
+        klasses = configs.map(&:klass)
+
+        configs.size.should == 2
+
+        [User, Post].each { |klass| klasses.include?(klass).should == true }
       end
     end
   end

--- a/spec/lib/sprig/harvest/model_config_spec.rb
+++ b/spec/lib/sprig/harvest/model_config_spec.rb
@@ -1,0 +1,139 @@
+require 'spec_helper'
+
+describe Sprig::Harvest::ModelConfig do
+  describe "#initialize" do
+    context "with a klass that is not a sublcass of ActiveRecord::Base" do
+      it "raises an error" do
+        expect {
+          described_class.new(Sprig::Directive)
+        }.to raise_error ArgumentError, 'Cannot create a seed file for Sprig::Directive because it is not a subclass of ActiveRecord::Base.'
+      end
+    end
+
+    context "with a subclass of ActiveRecord::Base" do
+      subject { described_class.new(User) }
+
+      its(:klass) { should == User }
+    end
+  end
+
+  describe "#collection" do
+    let!(:user1) { User.create(:first_name => 'Bo', last_name: 'Janglez') }
+    let!(:user2) { User.create(:first_name => 'Bo', last_name: 'Jinglez') }
+    let!(:user3) { User.create(:first_name => 'Bi', last_name: 'Jonglez') }
+
+    context "when no collection was given" do
+      subject { described_class.new(User) }
+
+      its(:collection) { should =~ [user1, user2, user3] }
+    end
+
+    context "when a collection was given" do
+      subject { described_class.new(User, :collection => [user1, user3]) }
+
+      its(:collection) { should == [user1, user3] }
+    end
+  end
+
+  describe "#limit" do
+    context "when no limit was given" do
+      subject { described_class.new(User) }
+
+      context "and there is no limit for all classes" do
+        before { Sprig::Harvest.stub(:limit) }
+        
+        its(:limit) { should == nil }
+      end
+
+      context "and there is a limit for all classes" do
+        before { Sprig::Harvest.stub(:limit).and_return(10) }
+
+        its(:limit) { should == 10 }
+      end
+    end
+
+    context "when a limit was given" do
+      subject do
+        described_class.new(User,
+          :limit => 25
+        )
+      end
+
+      context "and there is no limit for all classes" do
+        before { Sprig::Harvest.stub(:limit) }
+        
+        its(:limit) { should == 25 }
+      end
+
+      context "and there is a limit for all classes" do
+        before { Sprig::Harvest.stub(:limit).and_return(10) }
+
+        its(:limit) { should == 25 }
+      end
+    end
+  end
+
+  describe "#ignored_attrs" do
+    context "when no ignored attributes were given" do
+      subject { described_class.new(User) }
+
+      context "and there are no ignored attributes for all classes" do
+        before { Sprig::Harvest.stub(:ignored_attrs).and_return([]) }
+
+        its(:ignored_attrs) { should == [] }
+      end
+
+      context "but there are ignored attributes for all classes" do
+        before { Sprig::Harvest.stub(:ignored_attrs).and_return(['first_name']) }
+
+        its(:ignored_attrs) { should == ['first_name'] }
+      end
+    end
+
+    context "when ignored attributes were given" do
+      subject do
+        described_class.new(User,
+          :ignored_attrs => [:last_name]
+        )
+      end
+
+      its(:ignored_attrs) { should == ['last_name'] }
+
+      context "and there are ignored attributes for all classes" do
+        before { Sprig::Harvest.stub(:ignored_attrs).and_return(['first_name']) }
+
+        its(:ignored_attrs) { should =~ ['first_name', 'last_name'] }
+      end
+    end
+  end
+
+  describe "#attributes" do
+    context "when there are class-specific ignored attributes" do
+      subject do
+        described_class.new(User,
+          :ignored_attrs => [:last_name]
+        )
+      end
+
+      its(:attributes) { should == User.column_names - ['last_name'] }
+
+      context "as well as for all classes" do
+        before { Sprig::Harvest.stub(:ignored_attrs).and_return(['first_name']) }
+
+        its(:attributes) { should == User.column_names - ['first_name', 'last_name'] }
+      end
+    end
+
+    context "when there are no ignored attributes" do
+      subject { described_class.new(User) }
+
+      its(:attributes) { should == User.column_names }
+    end
+  end
+
+  describe "#dependencies" do
+    subject { described_class.new(Comment) }
+
+    its(:dependencies) { should == [Post] }
+  end
+end

--- a/spec/lib/sprig/harvest/seed_file_spec.rb
+++ b/spec/lib/sprig/harvest/seed_file_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Sprig::Harvest::SeedFile do
-  let(:model) { Sprig::Harvest::Model.new(Comment) }
+  let(:config) { Sprig::Harvest::ModelConfig.new(Comment) }
+  let(:model)  { Sprig::Harvest::Model.new(config) }
 
   subject { described_class.new(model) }
 

--- a/spec/lib/sprig/harvest_spec.rb
+++ b/spec/lib/sprig/harvest_spec.rb
@@ -1,12 +1,15 @@
 require 'spec_helper'
 
 describe Sprig::Harvest do
+  before do
+    stub_rails_root
+    stub_rails_env('dreamland')
+  end
+
   describe ".reap" do
     let(:seed_file) { double('Sprig::Harvest::SeedFile', :write => 'such seeds') }
 
     before do
-      stub_rails_root
-      stub_rails_env('dreamland')
       Sprig::Harvest::SeedFile.stub(:new).and_return(seed_file)
     end
 
@@ -18,6 +21,35 @@ describe Sprig::Harvest do
       seed_file.should_receive(:write).exactly(3).times
 
       subject.reap
+    end
+
+    context "given a reap config file in the options hash" do
+      let!(:bo)        { User.create(:first_name => 'Bo',    :last_name => 'Janglez') }
+      let!(:billy)     { User.create(:first_name => 'Billy', :last_name => 'Janglez') }
+      let!(:butch)     { User.create(:first_name => 'Butch', :last_name => 'Jillio') }
+      let(:file)       { './spec/fixtures/db/seeds/reap_config.rb' }
+
+      before { subject.reap(:file => file) }
+
+      its(:env)           { should == 'dreamland' }
+      its(:limit)         { should == 30 }
+      its(:ignored_attrs) { should == ['created_at', 'updated_at'] }
+
+      it "appropriately sets model-specific configurations" do
+        user_config    = subject.model_configurations.find { |config| config.klass == User }
+        post_config    = subject.model_configurations.find { |config| config.klass == Post }
+        comment_config = subject.model_configurations.find { |config| config.klass == Comment }
+
+        user_config.collection.should    == [bo, billy]
+        user_config.limit.should         == 10
+        user_config.ignored_attrs.should == ['type'] + ['created_at', 'updated_at']
+
+        post_config.limit.should         == 20
+        post_config.ignored_attrs.should == ['created_at', 'updated_at']
+
+        comment_config.limit.should         == 30
+        comment_config.ignored_attrs.should == ['created_at', 'updated_at']
+      end
     end
 
     context "when passed an environment in the options hash" do
@@ -36,18 +68,143 @@ describe Sprig::Harvest do
       end
     end
 
-    context "when passed a set of classes in the options hash" do
-      context "in :classes" do
-        it "sets the classes" do
+    context "when passed a set of models in the options hash" do
+      context "in :models" do
+        it "sets classes to the given models" do
           subject.reap(:models => [User, Post])
           subject.classes.should == [User, Post]
         end
       end
 
-      context "sets the classes" do
-        it "passes the value to its configuration" do
-          subject.reap('MODELS' => 'User, Post')
+      context "in MODELS" do
+        it "sets classes to the given models" do
+          subject.reap('MODELS' => ' User, Post')
           subject.classes.should == [User, Post]
+        end
+      end
+    end
+
+    context "when passed an limit in the options hash" do
+      context "in :limit" do
+        it "sets the limit" do
+          subject.reap(:limit => 10)
+          subject.limit.should == 10
+        end
+      end
+
+      context "in LIMIT" do
+        it "sets the limit" do
+          subject.reap('LIMIT' => ' 10')
+          subject.limit.should == 10
+        end
+      end
+    end
+
+    context "when passed a list of ignored attributes in the options hash" do
+      context "in :ignored_attrs" do
+        it "sets ignored attributes" do
+          subject.reap(:ignored_attrs => [:willy, :nilly])
+          subject.ignored_attrs.should == ['willy', 'nilly']
+        end
+      end
+
+      context "in IGNORED_ATTRS" do
+        it "sets ignored attributes" do
+          subject.reap('IGNORED_ATTRS' => ' willy, nilly')
+          subject.ignored_attrs.should == ['willy', 'nilly']
+        end
+      end
+    end
+  end
+
+  describe ".configure" do
+    describe "setting env" do
+      before do
+        subject.configure do |config|
+          config.env = 'dreamland'
+        end
+      end
+
+      its(:env) { should == 'dreamland' }
+    end
+
+    describe "setting classes" do
+      before do
+        subject.configure do |config|
+          config.classes = [User, Post]
+        end
+      end
+
+      its(:classes) { should == [User, Post] }
+    end
+
+    describe "setting limit" do
+      before do
+        subject.configure do |config|
+          config.limit = 25
+        end
+      end
+
+      its(:limit) { should == 25 }
+    end
+
+    describe "setting ignored attributes" do
+      before do
+        subject.configure do |config|
+          config.ignored_attrs = [:boom, :shaka, :laka]
+        end
+      end
+
+      its(:ignored_attrs) { should == ['boom', 'shaka', 'laka'] }
+    end
+
+    describe "setting models" do
+      context "with an array of model-specific configurations" do
+        let!(:user1) { User.create(:first_name => 'Bo',    :last_name => 'Janglez') }
+        let!(:user2) { User.create(:first_name => 'Billy', :last_name => 'Janglez') }
+
+        context "including a class" do
+          before do
+            subject.configure do |config|
+              config.models = [User]
+            end
+          end
+
+          it "creates the appropriate model configuration" do
+            config = subject.model_configurations.first
+
+            config.collection.should    == [user1, user2]
+            config.limit.should         == subject.limit
+            config.ignored_attrs.should == subject.ignored_attrs
+          end
+        end
+
+        context "including a hash of configurables" do
+          let(:options) do
+            {
+              :collection    => User.where(:first_name => 'Bo'),
+              :limit         => 5,
+              :ignored_attrs => [:willy, :nilly]
+            }
+          end
+
+          let(:model_config_input) do
+            { :class => User }.merge(options)
+          end
+
+          before do
+            subject.configure do |config|
+              config.models = [model_config_input]
+            end
+          end
+
+          it "creates the appropriate model configuration" do
+            config = subject.model_configurations.first
+
+            config.collection.should    == [user1]
+            config.limit.should         == 5
+            config.ignored_attrs.should == ['willy', 'nilly'] + subject.ignored_attrs
+          end
         end
       end
     end


### PR DESCRIPTION
#### Additional Options (`:limit` and `:ignored_attrs`)

```
# rake
rake db:seed:reap ENV=integration MODELS=User, Post LIMIT=10 IGNORED_ATTRS=created_at, updated_at

# console
Sprig::Harvest.reap(
  :env           => 'integration',
  :models        => [User, Post],
  :limit         => 10,
  :ignored_attrs => [:created_at, :updated_at]
)
```
#### File-Based Config (allows for model-by-model configuration)

```
# db/seeds/reap_config.rb

Sprig::Harvest.configure do |config|
  config.env           = 'dreamland'
  config.limit         = 30
  config.ignored_attrs = [:created_at, :updated_at]

  config.models = [
    {
      :class         => User,
      :collection    => User.active.where(:admin => false),
      :limit         => 10,
      :ignored_attrs => :password
    },

    {
      :class      => Post,
      :collection => Post.published,
      :limit      => 20
    },

    Comment
  ]
end
```

To use this reap config file, invoke `reap` via:

```
# rake
rake db:seed:reap FILE="./db/seeds/reap_config.rb"

# console
Sprig::Harvest.reap(:file => './db/seeds/reap_config.rb')
```
