### PR TITLE
Adds computed array attribute value support (allows for habtm)

### DIFF
--- a/lib/sprig/seed/attribute.rb
+++ b/lib/sprig/seed/attribute.rb
@@ -31,9 +31,9 @@ module Sprig
       end
 
       def find_dependencies_within_array(array)
-        array.map do |value|
+        array.flat_map do |value|
           find_dependencies_within(value)
-        end.flatten
+        end
       end
 
       def find_dependencies_within_string(string)

--- a/spec/fixtures/models/post.rb
+++ b/spec/fixtures/models/post.rb
@@ -1,5 +1,7 @@
 class Post < ActiveRecord::Base
 
+  has_and_belongs_to_many :tags
+
   def photo=(file)
     write_attribute(:photo, File.basename(file.path))
   end

--- a/spec/fixtures/models/tag.rb
+++ b/spec/fixtures/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ActiveRecord::Base
+  validates :name, :presence => true
+end

--- a/spec/fixtures/seeds/test/posts_with_habtm.yml
+++ b/spec/fixtures/seeds/test/posts_with_habtm.yml
@@ -1,0 +1,7 @@
+records:
+  - sprig_id: 1
+    title: 'Yaml title'
+    content: 'Yaml content'
+    tag_ids:
+      - '<%= sprig_record(Tag, 1).id %>'
+      - '<%= sprig_record(Tag, 2).id %>'

--- a/spec/fixtures/seeds/test/tags.yml
+++ b/spec/fixtures/seeds/test/tags.yml
@@ -1,0 +1,5 @@
+records:
+  - sprig_id: 1
+    name: 'Botany'
+  - sprig_id: 2
+    name: 'Biology'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,12 @@ Post.connection.execute "CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMEN
 Comment.connection.execute "DROP TABLE IF EXISTS comments;"
 Comment.connection.execute "CREATE TABLE comments (id INTEGER PRIMARY KEY , post_id INTEGER, body VARCHAR(255));"
 
+Tag.connection.execute "DROP TABLE IF EXISTS tags;"
+Tag.connection.execute "CREATE TABLE tags (id INTEGER PRIMARY KEY , name VARCHAR(255));"
+
+Tag.connection.execute "DROP TABLE IF EXISTS posts_tags;"
+Tag.connection.execute "CREATE TABLE posts_tags (id INTEGER PRIMARY KEY , post_id INTEGER, tag_id INTEGER);"
+
 # Helpers
 #
 # Setup fake `Rails.root`

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -235,6 +235,24 @@ describe "Seeding an application" do
     end
   end
 
+  context "with has_and_belongs_to_many relationships" do
+    around do |example|
+      load_seeds('posts_with_habtm.yml', 'tags.yml', &example)
+    end
+
+    it "saves the habtm relationships" do
+      sprig [
+        Tag,
+        {
+          :class  => Post,
+          :source => open('spec/fixtures/seeds/test/posts_with_habtm.yml')
+        }
+      ]
+
+      Post.first.tags.map(&:name).should == ['Botany', 'Biology']
+    end
+  end
+
   context "with cyclic dependencies" do
     around do |example|
       load_seeds('comments.yml', 'posts_with_cyclic_dependencies.yml', &example)


### PR DESCRIPTION
Fixes #31

This PR adds support for computed values within array attribute values. This allows us to define `has_and_belongs_to_many` relationships in seed files like so (assuming Post `has_and_belongs_to_many :tags`):

``` yaml
#posts.yml

records:
  - sprig_id: 1
    title: 'My Awesome Post'
    content: 'Lorem ipsum...'
    tag_ids:
      - '<%= sprig_record(Tag, 1).id %>'
      - '<%= sprig_record(Tag, 2).id %>'
```
