### PR TITLE
create class aliases for sti models

### DIFF
--- a/lib/sprig/sprig_record_store.rb
+++ b/lib/sprig/sprig_record_store.rb
@@ -8,6 +8,14 @@ module Sprig
 
     def save(record, sprig_id)
       records_of_klass(record.class)[sprig_id.to_s] = record
+
+      return unless record.class.column_names.include? record.class.inheritance_column
+
+      begin
+        sti_base_class = record.class.table_name.classify.constantize
+        records_of_klass(sti_base_class)[sprig_id.to_s] = record
+      rescue NameError
+      end
     end
 
     def get(klass, sprig_id)


### PR DESCRIPTION
This makes the sprig references also available via the sti base class.

So if you have `RedCar < Car` the record is accessible via both classes.

The specs doesn't run on my machine in master anyway so I don't know wether I broke something.
