### PR TITLE
Allow sharing seeds between environments while still allowing environment specific seeds to overwrite

### DIFF
--- a/lib/sprig/configuration.rb
+++ b/lib/sprig/configuration.rb
@@ -4,7 +4,11 @@ module Sprig
     attr_writer :directory, :logger
 
     def directory
-      Rails.root.join(@directory || default_directory, Rails.env)
+      Rails.root.join(@directory || default_directory)
+    end
+
+    def environment_directory
+      Rails.root.join(directory, Rails.env)
     end
 
     def logger

--- a/lib/sprig/helpers.rb
+++ b/lib/sprig/helpers.rb
@@ -4,6 +4,10 @@ module Sprig
       Sprig.configuration.directory
     end
 
+    def seed_environment_directory
+      Sprig.configuration.environment_directory
+    end
+
     def sprig(directive_definitions)
       hopper = []
       DirectiveList.new(directive_definitions).add_seeds_to_hopper(hopper)

--- a/lib/sprig/source.rb
+++ b/lib/sprig/source.rb
@@ -75,11 +75,28 @@ module Sprig
       class FileNotFoundError < StandardError; end
 
       def filename
-        available_files.detect {|name| name =~ /^#{table_name}\./ } || file_not_found
+        environment_specific_filename || root_filename || file_not_found
       end
 
-      def available_files
+      def root_filename
+        detect_file(available_root_files)
+      end
+
+      def environment_specific_filename
+        name = detect_file(available_environment_files)
+        name.prepend("#{Rails.env}/") unless name.nil?
+      end
+
+      def detect_file(files)
+        files.detect {|name| name =~ /^#{table_name}\./ }
+      end
+
+      def available_root_files
         Dir.entries(seed_directory)
+      end
+
+      def available_environment_files
+        Dir.entries(seed_environment_directory)
       end
 
       def file_not_found


### PR DESCRIPTION
SourceDeterminer checks environment subdirectories first, then defaults back to root seed directory. Fixes #2.

This allows you to have environment specific seeds, while still allowing
for shared seeds between environments.
