### PR TITLE
Adds support for symlinks as seed files

### DIFF
--- a/lib/sprig/source.rb
+++ b/lib/sprig/source.rb
@@ -67,7 +67,7 @@ module Sprig
       end
 
       def file
-        File.new(seed_directory.join(filename))
+        File.new(filepath)
       end
 
       private
@@ -76,6 +76,15 @@ module Sprig
 
       def filename
         available_files.detect {|name| name =~ /^#{table_name}\./ } || file_not_found
+      end
+
+      def filepath
+        path = seed_directory.join(filename)
+        if File.symlink?(path)
+          File.readlink(path)
+        else
+          path
+        end
       end
 
       def available_files

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -53,6 +53,23 @@ describe "Seeding an application" do
     end
   end
 
+  context "with a symlinked file" do
+    let(:env) { Rails.env }
+
+    around do |example|
+      `ln -s ./spec/fixtures/seeds/#{env}/posts.yml ./spec/fixtures/db/seeds/#{env}`
+      example.call
+      `rm ./spec/fixtures/db/seeds/#{env}/posts.yml`
+    end
+
+    it "seeds the db" do
+      sprig [Post]
+
+      Post.count.should == 1
+      Post.pluck(:title).should =~ ['Yaml title']
+    end
+  end
+
   context "with a google spreadsheet" do
     it "seeds the db", :vcr => { :cassette_name => 'google_spreadsheet_json_posts' } do
       sprig [


### PR DESCRIPTION
In some cases it can be handy to be able to share seed files between environments with simple symlinks.
This PR enables Sprig to detect symlinks used as seeds.

P.S. Thanks for the awesome gem people @viget :heart: 