### PR TITLE
Fixes partially dynamic attribute return values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sprig (0.1.9)
+    sprig (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/sprig/version.rb
+++ b/lib/sprig/version.rb
@@ -1,3 +1,3 @@
 module Sprig
-  VERSION = "0.1.9"
+  VERSION = "0.2.0"
 end

--- a/spec/fixtures/seeds/test/posts_partially_dynamic_value.yml
+++ b/spec/fixtures/seeds/test/posts_partially_dynamic_value.yml
@@ -1,0 +1,4 @@
+records:
+  - sprig_id: 1
+    title: '<%= "Partially-dynamic" %> title'
+    content: 'Yaml content'

--- a/spec/fixtures/seeds/test/posts_partially_dynamic_value.yml
+++ b/spec/fixtures/seeds/test/posts_partially_dynamic_value.yml
@@ -1,4 +1,4 @@
 records:
   - sprig_id: 1
-    title: '<%= "Partially-dynamic" %> title'
+    title: '<%= "Partially" %> <%= "Dynamic" %> Title'
     content: 'Yaml content'

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -67,7 +67,7 @@ describe "Seeding an application" do
       ]
 
       Post.count.should == 1
-      Post.pluck(:title).should =~ ['Partially-dynamic title']
+      Post.pluck(:title).should =~ ['Partially Dynamic Title']
     end
   end
 

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -53,6 +53,24 @@ describe "Seeding an application" do
     end
   end
 
+  context "with a partially-dynamic value" do
+    around do |example|
+      load_seeds('posts_partially_dynamic_value.yml', &example)
+    end
+
+    it "seeds the db with the full value" do
+      sprig [
+        {
+          :class  => Post,
+          :source => open('spec/fixtures/seeds/test/posts_partially_dynamic_value.yml')
+        }
+      ]
+
+      Post.count.should == 1
+      Post.pluck(:title).should =~ ['Partially-dynamic title']
+    end
+  end
+
   context "with a symlinked file" do
     let(:env) { Rails.env }
 


### PR DESCRIPTION
cc @averyvery & @h0tl33t :point_down: this fixes the bug that prevented us from using Sprig to nicely manage CK JSON.

Previously, if a value contained a dynamic aspect, the attribute value
returned by Sprig was just the dynamic component of the entire value.

This commit fixes this bug, allowing dynamic components to be returned
within larger strings. At the same time, we still allow the return of
non-string data structures from values that are entirely dynamic.
## Example

This would previously return `2` for the value of the title:

``` yaml
records:
   - sprig_id: 1
     title: 'Title <%= 2 %>'
```

Now it returns `"Title 2"` like everyone expects that it should.

But if you want, you can still return an integer by doing:

``` yaml
records:
   - sprig_id: 1
     upvote_count: '<%= 2 %>'
```
