### PR TITLE
Simple shared directory via config

### DIFF
--- a/lib/sprig/configuration.rb
+++ b/lib/sprig/configuration.rb
@@ -1,10 +1,14 @@
 module Sprig
   class Configuration
 
-    attr_writer :directory, :logger
+    attr_writer :directory, :logger, :shared_directory
 
     def directory
-      Rails.root.join(@directory || default_directory, Rails.env)
+      Rails.root.join(@directory || default_directory, source_directory)
+    end
+
+    def shared_directory
+      @shared_directory
     end
 
     def logger
@@ -12,6 +16,10 @@ module Sprig
     end
 
     private
+
+    def source_directory
+      shared_directory || Rails.env
+    end
 
     def default_directory
       'db/seeds'

--- a/spec/lib/sprig/configuration_spec.rb
+++ b/spec/lib/sprig/configuration_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe Sprig::Configuration do
     end
   end
 
+  describe "#shared_directory" do
+    it "returns nil by default" do
+      expect(subject.shared_directory).to be_nil
+    end
+
+    it "returns a shared directory" do
+      subject.shared_directory = 'shared'
+      subject.directory = 'seed_files'
+
+      expect(subject.directory.to_path).to eq('~/seed_files/shared')
+    end
+  end
+
   describe "#logger" do
     it "returns an stdout logger by default" do
       logger = double('Logger')


### PR DESCRIPTION
Works well in my case.
Able to configure/reconfigure after or before default environment seed.

``` ruby
Sprig.configure do |config|
  config.shared_directory = 'shared'
end
```

Yes, ideally we need something with merge functional. But currently i found this case pretty useful.
