### PR TITLE
Fix error when using a seed that is a relative symlink

### DIFF
--- a/lib/sprig/source.rb
+++ b/lib/sprig/source.rb
@@ -81,7 +81,7 @@ module Sprig
       def filepath
         path = seed_directory.join(filename)
         if File.symlink?(path)
-          File.readlink(path)
+          File.realpath(path)
         else
           path
         end

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -71,12 +71,25 @@ RSpec.describe "Seeding an application" do
     end
   end
 
-  context "with a symlinked file" do
+  context "with a relative symlink" do
     let(:env) { Rails.env }
 
     around do |example|
-      `ln -s ./spec/fixtures/seeds/#{env}/posts.yml ./spec/fixtures/db/seeds/#{env}`
+      # Create shared directory
+      `mkdir ./spec/fixtures/db/seeds/shared`
+
+      # Copy posts.yml to the shared directory
+      `cp ./spec/fixtures/seeds/#{env}/posts.yml ./spec/fixtures/db/seeds/shared/posts.yml`
+
+      # Create relative symlink in environment directory to shared directory
+      `cd ./spec/fixtures/db/seeds/#{env} && ln -s ../shared/posts.yml posts.yml`
+
       example.call
+
+      # Remove shared directory
+      `rm -dr ./spec/fixtures/db/seeds/shared`
+
+      # Remove posts.yml
       `rm ./spec/fixtures/db/seeds/#{env}/posts.yml`
     end
 


### PR DESCRIPTION
Fixes #92.

Note that this PR breaks the previous symlink test case, so I made the decision to replace it. The tested symlinks were relative paths, but they were relative to the root of the project, which doesn't really make sense. Symlinks should either be an absolute path or a path relative to the directory containing the symlink file.

cc @ltk