### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gem "sprig"
 ```
 Use `rails generate sprig:install` to create environment-specific seed directories.
 
-##The Sprig Directive
+## The Sprig Directive
 
 Within your seed file, you can use the `sprig` directive to initiate Sprig's dark magicks. A simple directive might look like this.
 
@@ -30,13 +30,13 @@ sprig [User, Post, Comment]
 
 This directive tells Sprig to go find your datafiles for the `User`, `Post`, and `Comment` seed resources, build records from the data entries, and insert them into the database. Sprig will automatically detect known datafile types like `.yml`, `.json`, or `.csv` within your environment-specific seed directory.
 
-##Environment
+## Environment
 
 Seed files are unique to the environment in which your Rails application is running. Within `db/seeds` create an environment-specific directory (i.e. `/development` for your 'development' environment).
 
 Todo: [Support for shared seed files]
 
-##Seed files
+## Seed files
 
 Hang your seed definitions on a `records` key for *yaml* and *json* files.
 
@@ -93,7 +93,7 @@ records:
 #### Has and Belongs to Many
 For `has_and_belongs_to_many` (HABTM) relationships, you may define relation ids in array format. So if `Post` `has_and_belongs_to_many :tags`, you could write:
 ```yaml
-#posts.yml
+# posts.yml
 
 records:
   - sprig_id: 42
@@ -104,7 +104,7 @@ records:
       - '<%= sprig_record(Tag, 2).id %>'
 ```
 ```yaml
-#tags.yml
+# tags.yml
 
 records:
   - sprig_id: 'bio'
@@ -146,7 +146,7 @@ records:
     published_at: "<%= 1.week.ago %>"
 ```
 
-##Custom Sources and Parsers
+## Custom Sources and Parsers
 
 If all your data is in `.wat` files, fear not. You can tell Sprig where to look for your data, and point it toward a custom parser class for turning your data into records. The example below tells Sprig to read `User` seed data from a Google Spreadsheet, and parse it accordingly.
 
@@ -166,7 +166,7 @@ sprig [
 ]
 ```
 
-##Configuration
+## Configuration
 
 When Sprig conventions don't suit, just add a configuration block to your seed file.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
