### PR TITLE
Fixed compute_string_value for a non-complete dynamic value

### DIFF
--- a/lib/sprig/seed/attribute.rb
+++ b/lib/sprig/seed/attribute.rb
@@ -96,7 +96,7 @@ module Sprig
           # Otherwise return the dynamic portion within the larger string.
           string.clone.tap do |return_string|
             matches.each do |match|
-              return_string.sub!(match[0], eval(match[1]))
+              return_string.sub!(match[0], eval(match[1]).to_s)
             end
           end
         end


### PR DESCRIPTION
For a non-complete dynamic value, non-string type values returned by eval can not be substituted in the return_string. For substitution within the return_string conversion of eval returned value to string is required.
So, Adding the .to_s to the value returned by eval for the match[1].