### PR TITLE
Don't attempt to overwrite readonly attributes

### DIFF
--- a/lib/sprig/seed/record.rb
+++ b/lib/sprig/seed/record.rb
@@ -32,6 +32,8 @@ module Sprig
 
       def populate_attributes
         attributes.each do |attribute|
+          next if existing? && attribute.name.in?(klass.readonly_attributes)
+
           orm_record.send(:"#{attribute.name}=", attribute.value)
         end
       end


### PR DESCRIPTION
This prevents `ActiveRecord::ReadonlyAttributeError` errors when using the `find_existing_by` option with ActiveRecord models using [read-only attributes](https://edgeapi.rubyonrails.org/classes/ActiveRecord/ReadonlyAttributes/ClassMethods.html).

When a persisted record is being seeded, a model's readonly attributes are skipped from being modified.  