### PR TITLE
Fix readonly attributes, allow collecting complete coverage data locally

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,19 @@ require "appraisal"
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+namespace :coverage do
+  desc "Run the spec suite against every Appraisal gemfile and aggregate coverage into one report"
+  task :aggregate do
+    sh "bundle exec appraisal install"
+    rm_rf "coverage"
+
+    appraisals = `bundle exec appraisal list`.split("\n").reject(&:empty?)
+
+    appraisals.each do |appraisal|
+      sh "bundle exec appraisal #{appraisal} rspec"
+    end
+
+    puts "Aggregated coverage report: file://#{File.expand_path("coverage/index.html")}"
+  end
+end

--- a/gemfiles/mongoid_8.gemfile
+++ b/gemfiles/mongoid_8.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "standardrb", "~> 1.0"
 gem "rails", "~> 7.2.0"
 gem "mongoid", "~> 8.0"
 gem "database_cleaner-mongoid"

--- a/gemfiles/mongoid_9.gemfile
+++ b/gemfiles/mongoid_9.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "standardrb", "~> 1.0"
 gem "rails", "~> 8.1.0"
 gem "mongoid", "~> 9.0"
 gem "database_cleaner-mongoid"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "standardrb", "~> 1.0"
 gem "rails", "~> 7.2.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "standardrb", "~> 1.0"
 gem "rails", "~> 8.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "standardrb", "~> 1.0"
 gem "rails", "~> 8.1.0"
 
 gemspec path: "../"

--- a/lib/sprig/seed/record.rb
+++ b/lib/sprig/seed/record.rb
@@ -32,6 +32,8 @@ module Sprig
 
       def populate_attributes
         attributes.each do |attribute|
+          next if existing? && attribute.name.in?(klass.readonly_attributes)
+
           orm_record.send(:"#{attribute.name}=", attribute.value)
         end
       end

--- a/lib/sprig/version.rb
+++ b/lib/sprig/version.rb
@@ -1,9 +1,9 @@
+#:nocov:
 module Sprig
-  #:nocov:
   VERSION = [
     0, # major
     3, # minor
     1  # patch
   ].join(".")
-  #:nocov:
 end
+#:nocov:

--- a/spec/adapters/active_record.rb
+++ b/spec/adapters/active_record.rb
@@ -22,7 +22,7 @@ User.connection.execute "DROP TABLE IF EXISTS users;"
 User.connection.execute "CREATE TABLE users (id INTEGER PRIMARY KEY , first_name VARCHAR(255), last_name VARCHAR(255), type VARCHAR(255));"
 
 Post.connection.execute "DROP TABLE IF EXISTS posts;"
-Post.connection.execute "CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title VARCHAR(255), content VARCHAR(255), photo VARCHAR(255), published BOOLEAN , user_id INTEGER);"
+Post.connection.execute "CREATE TABLE posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title VARCHAR(255), content VARCHAR(255), photo VARCHAR(255), published BOOLEAN , user_id INTEGER, readonly_field VARCHAR(255));"
 
 Comment.connection.execute "DROP TABLE IF EXISTS comments;"
 Comment.connection.execute "CREATE TABLE comments (id INTEGER PRIMARY KEY , post_id INTEGER, body VARCHAR(255));"

--- a/spec/fixtures/models/active_record/post.rb
+++ b/spec/fixtures/models/active_record/post.rb
@@ -1,6 +1,8 @@
 class Post < ActiveRecord::Base
   has_and_belongs_to_many :tags
 
+  attr_readonly :readonly_field
+
   def photo=(file)
     write_attribute(:photo, File.basename(file.path))
   end

--- a/spec/fixtures/models/mongoid/post.rb
+++ b/spec/fixtures/models/mongoid/post.rb
@@ -5,8 +5,11 @@ class Post
   field :title, type: String
   field :content, type: String
   field :published, type: Boolean
+  field :readonly_field, type: String
 
   has_and_belongs_to_many :tags
+
+  attr_readonly :readonly_field
 
   def photo=(file)
     write_attribute(:photo, File.basename(file.path))

--- a/spec/lib/sprig/seed/record_spec.rb
+++ b/spec/lib/sprig/seed/record_spec.rb
@@ -22,4 +22,42 @@ RSpec.describe Sprig::Seed::Record do
       expect(subject.existing?).to eq(false)
     end
   end
+
+  describe "#save" do
+    context "when the record already exists" do
+      let!(:existing) do
+        Post.create(
+          title: "Existing title",
+          content: "Existing content",
+          published: false,
+          readonly_field: "original value"
+        )
+      end
+
+      it "does not overwrite readonly attributes" do
+        attributes = Sprig::Seed::AttributeCollection.new(
+          title: "Existing title",
+          readonly_field: "changed value"
+        )
+        subject = described_class.new_or_existing(Post, attributes, {title: "Existing title"})
+
+        expect { subject.save }.not_to raise_error
+        expect(subject.orm_record.readonly_field).to eq("original value")
+      end
+    end
+
+    context "when the record is new" do
+      it "sets readonly attributes normally" do
+        attributes = Sprig::Seed::AttributeCollection.new(
+          title: "New title",
+          readonly_field: "initial value"
+        )
+        subject = described_class.new_or_existing(Post, attributes, {title: "New title"})
+
+        subject.save
+
+        expect(subject.orm_record.readonly_field).to eq("initial value")
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,11 @@ require "fileutils"
 
 SimpleCov.start "rails"
 
+# Each Appraisal gemfile runs as its own process, so without a distinct
+# command_name every run after the first overwrites the shared resultset
+# entry instead of merging into it (see SimpleCov::ResultMerger#store_result).
+SimpleCov.command_name(ENV["BUNDLE_GEMFILE"] ? File.basename(ENV["BUNDLE_GEMFILE"], ".gemfile") : "rspec")
+
 require "rails"
 require "pry"
 require "generator_spec"


### PR DESCRIPTION
- Fix issue where read-only attributes can attempt to be overwritten; adds test coverage (replaces #127 , but with test coverage)
- Allow collecting _complete_ test coverage data locally