### PR TITLE
[#79] Wrap Seeding in a Database Transaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test
-    services:
-      mongodb:
-        image: mongo:8
-        ports:
-          - 27017:27017
-        options: >-
-          --health-cmd "mongosh --quiet --eval 'db.runCommand(\"ping\")'"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -195,8 +195,20 @@ When Sprig conventions don't suit, just add a configuration block to your seed f
 Sprig.configure do |c|
   c.directory = 'seed_files'
   c.shared_directory = 'shared'
+  c.wrap_in_transaction = true
 end
 ```
+
+#### wrap_in_transaction
+
+Defaults to `true`. Sprig wraps each seeding run in a single transaction, so if any seed fails
+to save, everything planted during that run is rolled back and any remaining seeds are skipped.
+Set it to `false` to restore the previous best-effort behavior, where Sprig logs each failure and
+keeps planting the rest of the seeds regardless.
+
+Supported for both the `:active_record` and `:mongoid` adapters. Mongoid transactions require
+MongoDB to be running as a replica set (a single-node replica set is enough) — a standalone
+`mongod` doesn't support transactions.
 
 ## Populate Seed Files from Database
 

--- a/lib/sprig/configuration.rb
+++ b/lib/sprig/configuration.rb
@@ -1,6 +1,6 @@
 module Sprig
   class Configuration
-    attr_writer :directory, :shared_directory, :logger
+    attr_writer :directory, :shared_directory, :logger, :wrap_in_transaction
 
     def directory
       Rails.root.join(@directory || default_directory, seeds_directory)
@@ -8,6 +8,10 @@ module Sprig
 
     def logger
       @logger ||= Logger.new($stdout)
+    end
+
+    def wrap_in_transaction
+      defined?(@wrap_in_transaction) ? @wrap_in_transaction : true
     end
 
     private

--- a/lib/sprig/planter.rb
+++ b/lib/sprig/planter.rb
@@ -13,6 +13,11 @@ module Sprig
         dependency_sorted_seeds.each do |seed|
           plant(seed)
         end
+
+        if notifier.errors? && transactional_wrapping_requested_and_supported?
+          notifier.rollback
+          raise Rollback
+        end
       end
 
       notifier.finished
@@ -39,10 +44,8 @@ module Sprig
         notifier.success(seed)
       else
         notifier.error(seed)
-        raise Rollback if transactional_wrapping_requested_and_supported?
       end
     rescue => e
-      raise if e.instance_of?(Rollback)
       notifier.exception(seed, e)
     end
 

--- a/lib/sprig/planter.rb
+++ b/lib/sprig/planter.rb
@@ -1,12 +1,18 @@
 module Sprig
   class Planter
+    # Internal signal raised to trigger a rollback of the seeding transaction.
+    # Adapter-specific wrapping translates or rescues this as appropriate.
+    class Rollback < StandardError; end
+
     def initialize(seeds)
       @seeds = seeds.to_a
     end
 
     def sprig
-      dependency_sorted_seeds.each do |seed|
-        plant(seed)
+      wrap_in_transaction_if_supported do
+        dependency_sorted_seeds.each do |seed|
+          plant(seed)
+        end
       end
 
       notifier.finished
@@ -17,7 +23,7 @@ module Sprig
     attr_reader :seeds
 
     def dependency_sorted_seeds
-      DependencySorter.new(seeds).sorted_items
+      @dependency_sorted_seeds ||= DependencySorter.new(seeds).sorted_items
     end
 
     def notifier
@@ -33,9 +39,72 @@ module Sprig
         notifier.success(seed)
       else
         notifier.error(seed)
+        raise Rollback if transactional_wrapping_requested_and_supported?
       end
     rescue => e
+      raise if e.instance_of?(Rollback)
       notifier.exception(seed, e)
+    end
+
+    def transactional_wrapping_requested_and_supported?
+      Sprig.configuration.wrap_in_transaction && !transactional_anchor_class.nil?
+    end
+
+    def wrap_in_transaction_if_supported
+      return yield unless Sprig.configuration.wrap_in_transaction
+      return yield if dependency_sorted_seeds.empty?
+
+      klass = transactional_anchor_class
+
+      unless klass
+        notifier.warning("The `#{Sprig.adapter}` adapter doesn't support transactional wrapping.")
+        return yield
+      end
+
+      case Sprig.adapter
+      when :active_record
+        wrap_in_active_record_transaction(klass) { yield }
+      when :mongoid
+        wrap_in_mongoid_transaction(klass) { yield }
+      end
+    end
+
+    def wrap_in_active_record_transaction(klass)
+      klass.transaction do
+        begin
+          yield
+        rescue Rollback
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    # Mongoid's own `.transaction` convenience method (and
+    # `Mongoid::Errors::Rollback`) only exist as of Mongoid 9, so this drives
+    # the underlying Mongo::Session directly - `with_session`/`with_transaction`
+    # are available on every Mongoid version Sprig supports. All persistence
+    # operations inside the block pick up the session implicitly via
+    # Mongoid's thread-local session tracking.
+    def wrap_in_mongoid_transaction(klass)
+      klass.with_session do |session|
+        session.with_transaction { yield }
+      end
+    rescue Rollback
+      nil
+    end
+
+    # The class whose client a seeding run's transaction is anchored to.
+    # ActiveRecord's connection is shared across all its models, so
+    # ActiveRecord::Base works as a generic anchor. Mongoid sessions are
+    # scoped to a specific model's client, so a real seeded class has to be
+    # used instead of the `Mongoid::Document` module.
+    def transactional_anchor_class
+      case Sprig.adapter
+      when :active_record
+        ActiveRecord::Base
+      when :mongoid
+        dependency_sorted_seeds.first.klass
+      end
     end
   end
 end

--- a/lib/sprig/process_notifier.rb
+++ b/lib/sprig/process_notifier.rb
@@ -19,6 +19,10 @@ module Sprig
       @success_count += 1
     end
 
+    def warning(message)
+      log_warn message
+    end
+
     def error(seed)
       log_error seed.error_log_text
       log_error seed.record

--- a/lib/sprig/process_notifier.rb
+++ b/lib/sprig/process_notifier.rb
@@ -8,6 +8,8 @@ module Sprig
       @success_count = 0
       @error_count = 0
       @failure_summaries = []
+      @success_summaries = []
+      @rolled_back = false
     end
 
     def in_progress(seed)
@@ -17,6 +19,7 @@ module Sprig
     def success(seed)
       log_info seed.success_log_text
       @success_count += 1
+      @success_summaries << seed.success_summary_text
     end
 
     def warning(message)
@@ -38,9 +41,45 @@ module Sprig
       record_failure(seed.error_log_text)
     end
 
+    def errors?
+      @error_count > 0
+    end
+
+    def rollback
+      @rolled_back = true
+    end
+
     def finished
       log_debug "Seeding complete."
 
+      if @rolled_back
+        report_rollback
+      else
+        report_completion
+      end
+    end
+
+    private
+
+    def report_rollback
+      log_error rollback_summary
+
+      if @success_count > 0
+        log_error would_have_planted_summary
+
+        @success_summaries.each do |summary|
+          log_error summary
+        end
+      end
+
+      log_error error_summary
+
+      @failure_summaries.each do |summary|
+        log_error summary
+      end
+    end
+
+    def report_completion
       if @success_count > 0
         log_info success_summary
       else
@@ -56,8 +95,6 @@ module Sprig
       end
     end
 
-    private
-
     def record_failure(summary)
       @failure_summaries << summary
       @error_count += 1
@@ -65,6 +102,16 @@ module Sprig
 
     def success_summary
       "#{@success_count} #{"seed".pluralize(@success_count)} successfully planted."
+    end
+
+    def rollback_summary
+      "The seeding transaction was rolled back because #{@error_count} #{"seed".pluralize(@error_count)} " \
+        "failed to plant. NO records from this run were actually saved to the database."
+    end
+
+    def would_have_planted_summary
+      "The following #{@success_count} #{"seed".pluralize(@success_count)} would have been planted, " \
+        "but were rolled back along with everything else and were NOT saved:"
     end
 
     def error_summary

--- a/lib/sprig/seed/entry.rb
+++ b/lib/sprig/seed/entry.rb
@@ -52,6 +52,10 @@ module Sprig
         "There was an error saving #{klass.name} with sprig_id #{sprig_id}."
       end
 
+      def success_summary_text
+        "#{klass.name} with sprig_id #{sprig_id} (#{success_log_text})"
+      end
+
       def record
         @record ||= new_or_existing_record
       end

--- a/lib/sprig/seed/entry.rb
+++ b/lib/sprig/seed/entry.rb
@@ -1,6 +1,8 @@
 module Sprig
   module Seed
     class Entry
+      attr_reader :klass
+
       def initialize(klass, attrs, options)
         self.klass = klass
         attrs = attrs.to_hash.with_indifferent_access
@@ -56,7 +58,7 @@ module Sprig
 
       private
 
-      attr_reader :attributes, :klass, :options, :sprig_id
+      attr_reader :attributes, :options, :sprig_id
 
       def klass=(klass)
         raise ArgumentError, "First argument must be a Class" unless klass.is_a?(Class)

--- a/spec/adapters/mongoid.rb
+++ b/spec/adapters/mongoid.rb
@@ -1,9 +1,11 @@
 require "database_cleaner/mongoid"
 require "socket"
+require "open3"
 
 MONGO_TEST_CONTAINER = "sprig-mongo-test"
 MONGO_TEST_HOST = "localhost"
 MONGO_TEST_PORT = 27017
+MONGO_REPLICA_SET = "rs0"
 
 def mongo_port_open?
   TCPSocket.new(MONGO_TEST_HOST, MONGO_TEST_PORT).close
@@ -13,7 +15,12 @@ rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, SocketError
 end
 
 def mongo_container_exists?
-  `docker ps -aq -f name=^/#{MONGO_TEST_CONTAINER}$`.strip != ""
+  Open3.capture2("docker", "ps", "-aq", "-f", "name=^/#{MONGO_TEST_CONTAINER}$").first.strip != ""
+end
+
+def mongo_container_has_replica_set?
+  Open3.capture2("docker", "inspect", "--format", "{{json .Args}}", MONGO_TEST_CONTAINER)
+    .first.strip.include?("--replSet")
 end
 
 def wait_for_mongo_port!(timeout: 30)
@@ -29,12 +36,44 @@ def wait_for_mongo_port!(timeout: 30)
   end
 end
 
-def ensure_mongo_running!
-  return if mongo_port_open?
+def mongosh_eval(container, js)
+  Open3.capture2("docker", "exec", container, "mongosh", "--quiet", "--eval", js).first.strip
+end
 
-  unless system("docker", "info", out: File::NULL, err: File::NULL)
-    abort "MongoDB isn't reachable on #{MONGO_TEST_HOST}:#{MONGO_TEST_PORT}, and Docker isn't " \
-      "available to start it. Install/start Docker, or start MongoDB yourself on that host/port."
+def replica_set_initiated?
+  mongosh_eval(MONGO_TEST_CONTAINER, "rs.status().ok") == "1"
+end
+
+def replica_set_has_primary?
+  mongosh_eval(MONGO_TEST_CONTAINER, "rs.status().members.some(m => m.stateStr === 'PRIMARY')") == "true"
+end
+
+def initiate_replica_set!
+  return if replica_set_initiated?
+
+  mongosh_eval(MONGO_TEST_CONTAINER, <<~JS)
+    rs.initiate({
+      _id: "#{MONGO_REPLICA_SET}",
+      members: [{ _id: 0, host: "#{MONGO_TEST_HOST}:#{MONGO_TEST_PORT}" }]
+    })
+  JS
+end
+
+def wait_for_replica_set_primary!(timeout: 30)
+  deadline = Time.now + timeout
+
+  until replica_set_has_primary?
+    if Time.now > deadline
+      abort "MongoDB replica set '#{MONGO_REPLICA_SET}' did not elect a primary within #{timeout}s."
+    end
+
+    sleep 0.5
+  end
+end
+
+def start_mongo_container!
+  if mongo_container_exists? && !mongo_container_has_replica_set?
+    system("docker", "rm", "-f", MONGO_TEST_CONTAINER, out: File::NULL, err: File::NULL)
   end
 
   if mongo_container_exists?
@@ -43,10 +82,23 @@ def ensure_mongo_running!
     system("docker", "run", "-d", "--name", MONGO_TEST_CONTAINER,
       "-p", "#{MONGO_TEST_PORT}:#{MONGO_TEST_PORT}",
       "--tmpfs", "/data/db:size=256m", "--tmpfs", "/data/configdb:size=64m",
-      "mongo:8", out: File::NULL, err: File::NULL)
+      "mongo:8", "--replSet", MONGO_REPLICA_SET, out: File::NULL, err: File::NULL)
+  end
+end
+
+def ensure_mongo_running!
+  return if mongo_port_open?
+
+  unless system("docker", "info", out: File::NULL, err: File::NULL)
+    abort "MongoDB isn't reachable on #{MONGO_TEST_HOST}:#{MONGO_TEST_PORT}, and Docker isn't " \
+      "available to start it. Install/start Docker, or start a single-node replica set " \
+      "MongoDB yourself on that host/port (Sprig's Mongoid transaction support requires one)."
   end
 
+  start_mongo_container!
   wait_for_mongo_port!
+  initiate_replica_set!
+  wait_for_replica_set_primary!
 end
 
 ensure_mongo_running!

--- a/spec/fixtures/models/active_record/post.rb
+++ b/spec/fixtures/models/active_record/post.rb
@@ -2,6 +2,8 @@ class Post < ActiveRecord::Base
   has_and_belongs_to_many :tags
 
   attr_readonly :readonly_field
+  
+  validates :title, presence: true
 
   def photo=(file)
     write_attribute(:photo, File.basename(file.path))

--- a/spec/fixtures/models/mongoid/post.rb
+++ b/spec/fixtures/models/mongoid/post.rb
@@ -10,6 +10,8 @@ class Post
   has_and_belongs_to_many :tags
 
   attr_readonly :readonly_field
+  
+  validates :title, presence: true
 
   def photo=(file)
     write_attribute(:photo, File.basename(file.path))

--- a/spec/fixtures/seeds/test/posts_find_existing_by_missing_other_id.yml
+++ b/spec/fixtures/seeds/test/posts_find_existing_by_missing_other_id.yml
@@ -1,0 +1,7 @@
+options:
+  find_existing_by: 'unicorn'
+
+records:
+  - sprig_id: 2
+    title: 'Existing title'
+    content: 'Updated content'

--- a/spec/fixtures/seeds/test/posts_with_some_errors.yml
+++ b/spec/fixtures/seeds/test/posts_with_some_errors.yml
@@ -1,0 +1,7 @@
+records:
+  - sprig_id: 1
+    title: 'Yaml title'
+    content: 'Yaml content'
+  - sprig_id: 2
+    title:
+    content: 'Yaml content'

--- a/spec/fixtures/seeds/test/posts_with_some_errors_then_valid.yml
+++ b/spec/fixtures/seeds/test/posts_with_some_errors_then_valid.yml
@@ -1,0 +1,10 @@
+records:
+  - sprig_id: 1
+    title: 'First title'
+    content: 'Yaml content'
+  - sprig_id: 2
+    title:
+    content: 'Yaml content'
+  - sprig_id: 3
+    title: 'Third title'
+    content: 'Yaml content'

--- a/spec/lib/sprig/configuration_spec.rb
+++ b/spec/lib/sprig/configuration_spec.rb
@@ -33,4 +33,17 @@ RSpec.describe Sprig::Configuration do
       expect(subject.logger).to eq(logger)
     end
   end
+
+  describe "#wrap_in_transaction" do
+    it "returns true by default" do
+      expect(subject.wrap_in_transaction).to eq(true)
+    end
+
+    it "returns a custom value if provided" do
+      custom_value = false
+      subject.wrap_in_transaction = custom_value
+
+      expect(subject.wrap_in_transaction).to eq(custom_value)
+    end
+  end
 end

--- a/spec/lib/sprig/process_notifier_spec.rb
+++ b/spec/lib/sprig/process_notifier_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sprig::ProcessNotifier do
   end
 
   describe "#success" do
-    let(:seed) { double("Seed", success_log_text: "I am a teapot.") }
+    let(:seed) { double("Seed", success_log_text: "I am a teapot.", success_summary_text: "Teapot with sprig_id 1 (I am a teapot.)") }
 
     it "logs the seed's success message" do
       log_should_receive(:info, with: "I am a teapot.")
@@ -58,7 +58,7 @@ RSpec.describe Sprig::ProcessNotifier do
     end
 
     context "when records are saved successfully" do
-      let(:seed) { double("Seed", success_log_text: "I am a teapot.") }
+      let(:seed) { double("Seed", success_log_text: "I am a teapot.", success_summary_text: "Teapot with sprig_id 1 (I am a teapot.)") }
 
       before do
         subject.success(seed)
@@ -92,6 +92,55 @@ RSpec.describe Sprig::ProcessNotifier do
         log_should_receive(:error, with: "0 seeds successfully planted.").ordered
         log_should_receive(:error, with: "1 seed couldn't be planted:").ordered
         log_should_receive(:error, with: "I am a teapot.").ordered
+
+        subject.finished
+      end
+    end
+
+    context "when the run has been rolled back" do
+      let(:successful_seed) { double("Seed", success_log_text: "Saved", success_summary_text: "Post with sprig_id 1 (Saved)") }
+      let(:errors) { double("Errors", messages: "error messages") }
+      let(:seed_record) { double("Record", to_s: "Seed Record", errors: errors) }
+      let(:failed_seed) { double("Seed", error_log_text: "There was an error saving Post with sprig_id 2.", record: seed_record) }
+
+      before do
+        subject.success(successful_seed)
+        subject.error(failed_seed)
+        subject.rollback
+      end
+
+      it "explains the rollback, lists what would have been planted, and lists what failed" do
+        log_should_receive(:error, with: "The seeding transaction was rolled back because 1 seed failed to plant. NO records from this run were actually saved to the database.").ordered
+        log_should_receive(:error, with: "The following 1 seed would have been planted, but were rolled back along with everything else and were NOT saved:").ordered
+        log_should_receive(:error, with: "Post with sprig_id 1 (Saved)").ordered
+        log_should_receive(:error, with: "1 seed couldn't be planted:").ordered
+        log_should_receive(:error, with: "There was an error saving Post with sprig_id 2.").ordered
+
+        subject.finished
+      end
+
+      it "does not log the usual success summary" do
+        allow(Sprig.logger).to receive(:error)
+        expect(Sprig.logger).to_not receive(:info)
+
+        subject.finished
+      end
+    end
+
+    context "when the run has been rolled back with no successful seeds" do
+      let(:errors) { double("Errors", messages: "error messages") }
+      let(:seed_record) { double("Record", to_s: "Seed Record", errors: errors) }
+      let(:failed_seed) { double("Seed", error_log_text: "There was an error saving Post with sprig_id 2.", record: seed_record) }
+
+      before do
+        subject.error(failed_seed)
+        subject.rollback
+      end
+
+      it "skips the would-have-planted section" do
+        log_should_receive(:error, with: "The seeding transaction was rolled back because 1 seed failed to plant. NO records from this run were actually saved to the database.").ordered
+        log_should_receive(:error, with: "1 seed couldn't be planted:").ordered
+        log_should_receive(:error, with: "There was an error saving Post with sprig_id 2.").ordered
 
         subject.finished
       end

--- a/spec/lib/sprig/process_notifier_spec.rb
+++ b/spec/lib/sprig/process_notifier_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe Sprig::ProcessNotifier do
     end
   end
 
+  describe "#warning" do
+    it "logs the provided message as a warning" do
+      message = "oh noes!"
+      log_should_receive(:warn, with: message)
+
+      subject.warning(message)
+    end
+  end
+
   describe "#error" do
     let(:errors) { double("Errors", messages: "error messages") }
     let(:seed_record) { double("Record", to_s: "Seed Record", errors: errors) }

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -549,5 +549,49 @@ RSpec.describe "Seeding an application" do
         expect(Post.count).to eq(0)
       end
     end
+
+    context "with an error followed by a seed that would otherwise succeed" do
+      around do |example|
+        load_seeds("posts_with_some_errors_then_valid.yml", &example)
+      end
+
+      it "still attempts the later seed before rolling everything back" do
+        allow(Sprig.logger).to receive(:info)
+        allow(Sprig.logger).to receive(:error)
+        expect(Sprig.logger).to receive(:info).with(log_info_text("Saved")).twice
+
+        sprig [
+          {
+            class: Post,
+            source: open("spec/fixtures/seeds/test/posts_with_some_errors_then_valid.yml")
+          }
+        ]
+
+        expect(Post.count).to eq(0)
+      end
+    end
+
+    context "with an exception raised while planting (rather than a failed validation)" do
+      around do |example|
+        load_seeds("posts.yml", "posts_find_existing_by_missing_other_id.yml", &example)
+      end
+
+      it "rolls back records that had already been saved, and explains why in the summary" do
+        allow(Sprig.logger).to receive(:error)
+
+        log_should_receive(:error, with: "The seeding transaction was rolled back because 1 seed failed to plant. " \
+          "NO records from this run were actually saved to the database.")
+        log_should_receive(:error, with: "The following 1 seed would have been planted, but were rolled back " \
+          "along with everything else and were NOT saved:")
+        log_should_receive(:error, with: "Post with sprig_id 1 (Saved)")
+
+        sprig [
+          {class: Post, source: open("spec/fixtures/seeds/test/posts.yml")},
+          {class: Post, source: open("spec/fixtures/seeds/test/posts_find_existing_by_missing_other_id.yml")}
+        ]
+
+        expect(Post.count).to eq(0)
+      end
+    end
   end
 end

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -506,4 +506,48 @@ RSpec.describe "Seeding an application" do
       end
     end
   end
+
+  context "with Sprig configured to wrap the planting process in a transaction" do
+    before do
+      Sprig.configure do |c|
+        c.wrap_in_transaction = true
+      end
+    end
+
+    after do
+      Sprig.configure do |c|
+        c.wrap_in_transaction = false
+      end
+    end
+
+    context "with no errors" do
+      around do |example|
+        load_seeds('posts.yml', &example)
+      end
+
+      it "adds all the records to the database" do
+        sprig [Post]
+
+        expect(Post.count).to eq(1)
+        expect(Post.pluck(:title)).to match_array(['Yaml title'])
+      end
+    end
+
+    context "with some errors" do
+      around do |example|
+        load_seeds('posts_with_some_errors.yml', &example)
+      end
+
+      it "adds no records to the database" do
+        sprig [
+          {
+          :class  => Post,
+          :source => open('spec/fixtures/seeds/test/posts_with_some_errors.yml')
+          }
+        ]
+
+        expect(Post.count).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Ticket

#79 

(Optionally) wrap seeding process in a database transaction, that way the changes are rolled back if the process fails hard/is aborted halfway through.

Change default behavior to be YES to a transaction (since that should be what most people use)