### PR TITLE
[#75] Resolve Excessive Memory - Part 2 Defer Seed Hydration

### DIFF
--- a/benchmark/part-2.md
+++ b/benchmark/part-2.md
@@ -1,8 +1,5 @@
 # Part 2: introduce `Seed::Descriptor`; defer `Entry` materialization to plant time
 
-Port of the original, pre-`master`-rebase investigation's Option B (`6df0cad`) onto
-current `master`.
-
 ## What it does
 
 `Factory#add_seeds_to_hopper` used to turn every parsed row into a full `Seed::Entry` up
@@ -19,45 +16,21 @@ one.
 A `Descriptor` is intentionally cheap: just the class, the raw row data, and the options
 -- nothing wrapped, nothing type-cast. An `Entry`, by contrast, wraps every field in its
 own `Attribute` (type-cast/dirty-tracking machinery), which costs real memory per field.
-Since every record still waiting to plant sits in memory as *something* until its
+Since every record still waiting to plant sits in memory as _something_ until its
 dependencies resolve, the cost of "something" matters directly: swapping the retained
-object from `Entry` to `Descriptor` doesn't change *how many* records wait or *how long*,
-only *how much each one costs while it does*.
+object from `Entry` to `Descriptor` doesn't change _how many_ records wait or _how long_,
+only _how much each one costs while it does_.
 
 ## Empirical evidence
 
-| Tier | Peak RSS | vs. part-1 | Storage-space-over-time | vs. part-1 |
-|---|---:|---:|---:|---:|
-| Small (1K) | 93.3 MB | -9.0% | 171.5 MB\*s | -7.9% |
-| Medium (10K) | 370.4 MB | -10.1% | 6,809.0 MB\*s | -11.7% |
-| Large (100K) | 2,168.3 MB | -23.0% | 896,868.3 MB\*s | -1.6% |
+| Tier         |   Peak RSS | vs. part-1 | Storage-space-over-time | vs. part-1 |
+| ------------ | ---------: | ---------: | ----------------------: | ---------: |
+| Small (1K)   |    93.3 MB |      -9.0% |             171.5 MB\*s |      -7.9% |
+| Medium (10K) |   370.4 MB |     -10.1% |           6,809.0 MB\*s |     -11.7% |
+| Large (100K) | 2,168.3 MB |     -23.0% |         896,868.3 MB\*s |      -1.6% |
 
 Per-item retained-structure cost, measured directly via `ObjectSpace` (medium tier, final
 snapshot): a `Descriptor` costs ~1,552 bytes, versus a fully-built `Entry`'s ~7,168 bytes
 at part-1 -- roughly 22% of an `Entry`'s footprint, a larger reduction than the ~40%-less
 figure cited in this codebase's own earlier process documentation for an equivalent-sized
 row.
-
-## Additional notes
-
-Beyond the port itself, this stage needed integration work caused by `master` having
-moved on since the original investigation branched:
-
-- `Descriptor`'s dependency-detection now reuses `Attribute`'s own
-  `SPRIG_RECORD_REFERENCE`/`ID_LITERAL` constants (added to `master` after the original
-  stack branched) instead of a second, hand-copied numeric-only regex -- the original
-  port's copy predates that fix and would have silently regressed quoted/symbol
-  `sprig_id`s for any seed file using them in a cross-reference.
-- `Descriptor` gained a public `klass` reader (the original made it private). `master`'s
-  transactional `Planter` reads `dependency_sorted_seeds.first.klass` to pick a Mongoid
-  transaction anchor -- caught by running the ported `planter_spec.rb` against the
-  mongoid-9 Appraisal, not just the default ActiveRecord suite.
-- The ported `planter_spec.rb`'s doubles needed `errors?: false` and `klass: Post` added,
-  since `master`'s `Planter#sprig` now always calls `notifier.errors?` (for the
-  transaction-rollback check) and the Mongoid anchor-class path reads `.klass` off the
-  first seed -- neither existed when this spec was originally written against the old,
-  pre-transactional `Planter`.
-
-Full spec suite (168 examples) passed on the default (ActiveRecord) config, the
-rails-8.1 Appraisal, and the mongoid-9 Appraisal at the time this stage was ported;
-standardrb clean on every changed file.

--- a/benchmark/part-2.md
+++ b/benchmark/part-2.md
@@ -1,0 +1,63 @@
+# Part 2: introduce `Seed::Descriptor`; defer `Entry` materialization to plant time
+
+Port of the original, pre-`master`-rebase investigation's Option B (`6df0cad`) onto
+current `master`.
+
+## What it does
+
+`Factory#add_seeds_to_hopper` used to turn every parsed row into a full `Seed::Entry` up
+front -- attributes wrapped, values pre-processed -- before dependency order was even
+known, so the whole hopper held heavy objects for every table for the entire sort+plant
+run. `Factory` now pushes a lightweight `Descriptor` instead (raw row + class + options);
+`Planter#plant` calls `descriptor.to_entry` to build the real `Entry` only at the instant
+a record is about to be saved. `Entry#initialize` gained an optional `sprig_id` argument
+so the id the descriptor already computed carries through instead of re-rolling a second
+one.
+
+## How it helps
+
+A `Descriptor` is intentionally cheap: just the class, the raw row data, and the options
+-- nothing wrapped, nothing type-cast. An `Entry`, by contrast, wraps every field in its
+own `Attribute` (type-cast/dirty-tracking machinery), which costs real memory per field.
+Since every record still waiting to plant sits in memory as *something* until its
+dependencies resolve, the cost of "something" matters directly: swapping the retained
+object from `Entry` to `Descriptor` doesn't change *how many* records wait or *how long*,
+only *how much each one costs while it does*.
+
+## Empirical evidence
+
+| Tier | Peak RSS | vs. part-1 | Storage-space-over-time | vs. part-1 |
+|---|---:|---:|---:|---:|
+| Small (1K) | 93.3 MB | -9.0% | 171.5 MB\*s | -7.9% |
+| Medium (10K) | 370.4 MB | -10.1% | 6,809.0 MB\*s | -11.7% |
+| Large (100K) | 2,168.3 MB | -23.0% | 896,868.3 MB\*s | -1.6% |
+
+Per-item retained-structure cost, measured directly via `ObjectSpace` (medium tier, final
+snapshot): a `Descriptor` costs ~1,552 bytes, versus a fully-built `Entry`'s ~7,168 bytes
+at part-1 -- roughly 22% of an `Entry`'s footprint, a larger reduction than the ~40%-less
+figure cited in this codebase's own earlier process documentation for an equivalent-sized
+row.
+
+## Additional notes
+
+Beyond the port itself, this stage needed integration work caused by `master` having
+moved on since the original investigation branched:
+
+- `Descriptor`'s dependency-detection now reuses `Attribute`'s own
+  `SPRIG_RECORD_REFERENCE`/`ID_LITERAL` constants (added to `master` after the original
+  stack branched) instead of a second, hand-copied numeric-only regex -- the original
+  port's copy predates that fix and would have silently regressed quoted/symbol
+  `sprig_id`s for any seed file using them in a cross-reference.
+- `Descriptor` gained a public `klass` reader (the original made it private). `master`'s
+  transactional `Planter` reads `dependency_sorted_seeds.first.klass` to pick a Mongoid
+  transaction anchor -- caught by running the ported `planter_spec.rb` against the
+  mongoid-9 Appraisal, not just the default ActiveRecord suite.
+- The ported `planter_spec.rb`'s doubles needed `errors?: false` and `klass: Post` added,
+  since `master`'s `Planter#sprig` now always calls `notifier.errors?` (for the
+  transaction-rollback check) and the Mongoid anchor-class path reads `.klass` off the
+  first seed -- neither existed when this spec was originally written against the old,
+  pre-transactional `Planter`.
+
+Full spec suite (168 examples) passed on the default (ActiveRecord) config, the
+rails-8.1 Appraisal, and the mongoid-9 Appraisal at the time this stage was ported;
+standardrb clean on every changed file.

--- a/lib/sprig/planter.rb
+++ b/lib/sprig/planter.rb
@@ -37,16 +37,17 @@ module Sprig
 
     def plant(seed)
       notifier.in_progress(seed)
-      seed.before_save
+      entry = seed.to_entry
+      entry.before_save
 
-      if seed.save_record
-        seed.save_to_store
-        notifier.success(seed)
+      if entry.save_record
+        entry.save_to_store
+        notifier.success(entry)
       else
-        notifier.error(seed)
+        notifier.error(entry)
       end
     rescue => e
-      notifier.exception(seed, e)
+      notifier.exception(entry || seed, e)
     end
 
     def transactional_wrapping_requested_and_supported?

--- a/lib/sprig/seed.rb
+++ b/lib/sprig/seed.rb
@@ -2,6 +2,7 @@ module Sprig
   module Seed
     autoload :Attribute, "sprig/seed/attribute"
     autoload :AttributeCollection, "sprig/seed/attribute_collection"
+    autoload :Descriptor, "sprig/seed/descriptor"
     autoload :Entry, "sprig/seed/entry"
     autoload :Factory, "sprig/seed/factory"
     autoload :Record, "sprig/seed/record"

--- a/lib/sprig/seed/descriptor.rb
+++ b/lib/sprig/seed/descriptor.rb
@@ -1,0 +1,68 @@
+module Sprig
+  module Seed
+    class Descriptor
+      # Reuses Attribute's own reference/id-literal patterns (SPRIG_RECORD_REFERENCE,
+      # ID_LITERAL) rather than maintaining a second, independently-drifting copy of
+      # what counts as a valid sprig_record(...) reference -- see Attribute for the
+      # full explanation of what each shape matches. Descriptor never evals anything,
+      # so it only needs Attribute's dependency-detection rules, not its
+      # value-computation logic.
+      COMPUTED_VALUE_REGEX = /(<%=?(.*?)%>)/
+
+      attr_reader :klass
+
+      def initialize(klass, raw_attrs, options)
+        @klass = klass
+        @raw_attrs = raw_attrs
+        @options = options
+      end
+
+      def dependency_id
+        @dependency_id ||= Dependency.for(klass, sprig_id).id
+      end
+
+      def dependencies
+        @dependencies ||= [].tap do |deps|
+          raw_attrs.each_pair do |key, value|
+            next if key.to_s == "sprig_id"
+
+            scan_value(value) { |dep_klass, dep_sprig_id| deps << Dependency.for(dep_klass, dep_sprig_id) }
+          end
+        end.uniq
+      end
+
+      def sprig_id
+        @sprig_id ||= raw_attrs[:sprig_id] || raw_attrs["sprig_id"] || SecureRandom.uuid
+      end
+
+      def in_progress_text
+        "Planting #{klass.name} with sprig_id #{sprig_id}"
+      end
+
+      def error_log_text
+        "There was an error saving #{klass.name} with sprig_id #{sprig_id}."
+      end
+
+      def to_entry
+        Entry.new(klass, raw_attrs, options, sprig_id)
+      end
+
+      private
+
+      attr_reader :raw_attrs, :options
+
+      def scan_value(value, &block)
+        if value.is_a?(Array)
+          value.each { |v| scan_value(v, &block) }
+        elsif value.is_a?(String) && String(value) =~ COMPUTED_VALUE_REGEX
+          value.scan(Attribute::SPRIG_RECORD_REFERENCE).each { |dep_klass, id_text| block.call(dep_klass, id_from(id_text)) }
+        end
+      end
+
+      def id_from(id_text)
+        single_quoted, double_quoted, symbol, numeric = Attribute::ID_LITERAL.match(id_text)&.captures
+        single_quoted || double_quoted || symbol || numeric
+      end
+    end
+  end
+end

--- a/lib/sprig/seed/descriptor.rb
+++ b/lib/sprig/seed/descriptor.rb
@@ -1,12 +1,6 @@
 module Sprig
   module Seed
     class Descriptor
-      # Reuses Attribute's own reference/id-literal patterns (SPRIG_RECORD_REFERENCE,
-      # ID_LITERAL) rather than maintaining a second, independently-drifting copy of
-      # what counts as a valid sprig_record(...) reference -- see Attribute for the
-      # full explanation of what each shape matches. Descriptor never evals anything,
-      # so it only needs Attribute's dependency-detection rules, not its
-      # value-computation logic.
       COMPUTED_VALUE_REGEX = /(<%=?(.*?)%>)/
 
       attr_reader :klass

--- a/lib/sprig/seed/entry.rb
+++ b/lib/sprig/seed/entry.rb
@@ -3,10 +3,11 @@ module Sprig
     class Entry
       attr_reader :klass
 
-      def initialize(klass, attrs, options)
+      def initialize(klass, attrs, options, sprig_id = nil)
         self.klass = klass
         attrs = attrs.to_hash.with_indifferent_access
-        self.sprig_id = attrs.delete(:sprig_id) || SecureRandom.uuid
+        extracted_sprig_id = attrs.delete(:sprig_id)
+        self.sprig_id = sprig_id || extracted_sprig_id || SecureRandom.uuid
         @attributes = AttributeCollection.new(attrs)
         @options = options
       end

--- a/lib/sprig/seed/factory.rb
+++ b/lib/sprig/seed/factory.rb
@@ -19,7 +19,7 @@ module Sprig
 
       def add_seeds_to_hopper(hopper)
         datasource.records.each do |record_data|
-          hopper << Entry.new(klass, record_data, options)
+          hopper << Descriptor.new(klass, record_data, options)
         end
       end
 

--- a/spec/lib/sprig/dependency_sorter_spec.rb
+++ b/spec/lib/sprig/dependency_sorter_spec.rb
@@ -42,5 +42,14 @@ RSpec.describe Sprig::DependencySorter do
         "Referenced 'sprig_record' does not have a correlating record."
       )
     end
+
+    it "works against a real Sprig::Seed::Descriptor, not just an interface-compatible double" do
+      parent = Sprig::Seed::Descriptor.new(Post, {"sprig_id" => "1", "title" => "Parent"}, {})
+      child = Sprig::Seed::Descriptor.new(Post, {"sprig_id" => "2", "content" => "<%= sprig_record(Post, 1) %>"}, {})
+
+      sorted = described_class.new([child, parent]).sorted_items
+
+      expect(sorted).to eq([parent, child])
+    end
   end
 end

--- a/spec/lib/sprig/planter_spec.rb
+++ b/spec/lib/sprig/planter_spec.rb
@@ -1,0 +1,75 @@
+require "spec_helper"
+
+RSpec.describe Sprig::Planter do
+  describe "#sprig" do
+    let(:notifier) { double("notifier", in_progress: nil, finished: nil, errors?: false) }
+
+    before do
+      allow(Sprig::ProcessNotifier).to receive(:new).and_return(notifier)
+    end
+
+    context "when planting succeeds" do
+      let(:entry) { double("entry") }
+      let(:seed) { double("seed", dependency_id: "a", dependencies: [], klass: Post, to_entry: entry) }
+
+      it "materializes the entry via to_entry and drives it through the save lifecycle in order" do
+        expect(entry).to receive(:before_save).ordered
+        expect(entry).to receive(:save_record).ordered.and_return(true)
+        expect(entry).to receive(:save_to_store).ordered
+        expect(notifier).to receive(:success).with(entry).ordered
+
+        described_class.new([seed]).sprig
+      end
+
+      it "notifies in_progress with the un-materialized seed before building the entry" do
+        expect(notifier).to receive(:in_progress).with(seed)
+        allow(notifier).to receive(:success)
+        allow(entry).to receive(:before_save)
+        allow(entry).to receive(:save_record).and_return(true)
+        allow(entry).to receive(:save_to_store)
+
+        described_class.new([seed]).sprig
+      end
+    end
+
+    context "when save_record returns false" do
+      let(:entry) { double("entry", before_save: nil, save_record: false) }
+      let(:seed) { double("seed", dependency_id: "a", dependencies: [], klass: Post, to_entry: entry) }
+
+      it "calls notifier.error with the materialized entry, not the seed" do
+        expect(notifier).to receive(:error).with(entry)
+
+        described_class.new([seed]).sprig
+      end
+    end
+
+    context "when an exception is raised after the entry is materialized" do
+      let(:entry) { double("entry") }
+      let(:seed) { double("seed", dependency_id: "a", dependencies: [], klass: Post, to_entry: entry) }
+
+      before do
+        allow(entry).to receive(:before_save).and_raise(RuntimeError, "boom")
+      end
+
+      it "calls notifier.exception with the materialized entry" do
+        expect(notifier).to receive(:exception).with(entry, instance_of(RuntimeError))
+
+        described_class.new([seed]).sprig
+      end
+    end
+
+    context "when to_entry itself raises, before any entry exists" do
+      let(:seed) { double("seed", dependency_id: "a", dependencies: [], klass: Post) }
+
+      before do
+        allow(seed).to receive(:to_entry).and_raise(RuntimeError, "materialization failed")
+      end
+
+      it "calls notifier.exception with the un-materialized seed instead of raising a secondary error" do
+        expect(notifier).to receive(:exception).with(seed, instance_of(RuntimeError))
+
+        described_class.new([seed]).sprig
+      end
+    end
+  end
+end

--- a/spec/lib/sprig/seed/descriptor_spec.rb
+++ b/spec/lib/sprig/seed/descriptor_spec.rb
@@ -1,0 +1,156 @@
+require "spec_helper"
+
+RSpec.describe Sprig::Seed::Descriptor do
+  describe "#dependency_id" do
+    it "matches Dependency.for(klass, sprig_id).id for an explicit sprig_id" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello"}, {})
+
+      expect(descriptor.dependency_id).to eq(Sprig::Dependency.for(Post, "1").id)
+    end
+
+    it "is memoized" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello"}, {})
+
+      expect(descriptor.dependency_id).to eq(descriptor.dependency_id)
+    end
+
+    it "does not raise when sprig_id is absent from the row" do
+      descriptor = described_class.new(Post, {"title" => "Hello"}, {})
+
+      expect { descriptor.dependency_id }.not_to raise_error
+    end
+  end
+
+  describe "#dependencies" do
+    it "is empty for plain attributes with no sprig_record references" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello", "content" => "World"}, {})
+
+      expect(descriptor.dependencies).to eq([])
+    end
+
+    it "detects a single ERB-wrapped sprig_record reference" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "user_id" => "<%= sprig_record(Comment, 5) %>"}, {})
+
+      expect(descriptor.dependencies).to eq([Sprig::Dependency.for(Comment, "5")])
+    end
+
+    it "detects multiple ERB-wrapped sprig_record references inside an array attribute" do
+      descriptor = described_class.new(Post, {
+        "sprig_id" => "1",
+        "tag_ids" => ["<%= sprig_record(Comment, 1) %>", "<%= sprig_record(Comment, 2) %>"]
+      }, {})
+
+      expect(descriptor.dependencies).to contain_exactly(
+        Sprig::Dependency.for(Comment, "1"),
+        Sprig::Dependency.for(Comment, "2")
+      )
+    end
+
+    it "does not count a plain-text mention of sprig_record(...) with no ERB wrapper" do
+      descriptor = described_class.new(Post, {
+        "sprig_id" => "1",
+        "content" => "see sprig_record(Comment, 5) for context"
+      }, {})
+
+      expect(descriptor.dependencies).to eq([])
+    end
+
+    it "uniqs duplicate dependencies referenced from multiple attributes" do
+      descriptor = described_class.new(Post, {
+        "sprig_id" => "1",
+        "title" => "<%= sprig_record(Comment, 1) %>",
+        "content" => "<%= sprig_record(Comment, 1) %>"
+      }, {})
+
+      expect(descriptor.dependencies).to eq([Sprig::Dependency.for(Comment, "1")])
+    end
+
+    it "never scans the sprig_id attribute itself" do
+      descriptor = described_class.new(Post, {
+        "sprig_id" => "<%= sprig_record(Comment, 1) %>",
+        "title" => "Hello"
+      }, {})
+
+      expect(descriptor.dependencies).to eq([])
+    end
+
+    it "does not eval a fully-dynamic ERB attribute (and so does not raise even if it would blow up)" do
+      descriptor = described_class.new(Post, {
+        "sprig_id" => "1",
+        "title" => "<%= raise \"should never run\" %>"
+      }, {})
+
+      expect { descriptor.dependencies }.not_to raise_error
+      expect(descriptor.dependencies).to eq([])
+    end
+
+    it "resolves a quoted, non-numeric sprig_id the same way Attribute does" do
+      descriptor = described_class.new(Post, {
+        "sprig_id" => "1",
+        "user_id" => "<%= sprig_record(Comment, 'cooldev') %>"
+      }, {})
+
+      expect(descriptor.dependencies).to eq([Sprig::Dependency.for(Comment, "cooldev")])
+    end
+  end
+
+  describe "#to_entry" do
+    it "returns a Sprig::Seed::Entry" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello", "content" => "World"}, {})
+
+      expect(descriptor.to_entry).to be_a(Sprig::Seed::Entry)
+    end
+
+    it "produces an Entry with the same dependency_id when sprig_id is explicit" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello"}, {})
+
+      expect(descriptor.to_entry.dependency_id).to eq(descriptor.dependency_id)
+    end
+
+    it "produces an Entry with the same dependency_id when sprig_id is auto-generated" do
+      descriptor = described_class.new(Post, {"title" => "Hello"}, {})
+
+      expect(descriptor.to_entry.dependency_id).to eq(descriptor.dependency_id)
+    end
+
+    it "does not mutate raw_attrs, so plain attribute values still reach the resulting Entry correctly" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello", "content" => "World"}, {})
+
+      # Force dependency_id/dependencies/sprig_id to memoize before materializing the Entry.
+      descriptor.dependency_id
+      descriptor.dependencies
+
+      entry = descriptor.to_entry
+      entry.save_record
+
+      expect(Post.last.title).to eq("Hello")
+      expect(Post.last.content).to eq("World")
+    end
+  end
+
+  describe "memory characteristics" do
+    it "never materializes Attribute/AttributeCollection objects when computing dependency_id/dependencies" do
+      GC.start
+      attribute_count_before = ObjectSpace.each_object(Sprig::Seed::Attribute).count
+      collection_count_before = ObjectSpace.each_object(Sprig::Seed::AttributeCollection).count
+
+      descriptors = Array.new(50) do |i|
+        described_class.new(Post, {
+          "sprig_id" => i.to_s,
+          "title" => "Post #{i}",
+          "user_id" => (i > 0) ? "<%= sprig_record(Post, #{i - 1}) %>" : nil
+        }, {})
+      end
+      descriptors.each do |descriptor|
+        descriptor.dependency_id
+        descriptor.dependencies
+      end
+
+      attribute_count_after = ObjectSpace.each_object(Sprig::Seed::Attribute).count
+      collection_count_after = ObjectSpace.each_object(Sprig::Seed::AttributeCollection).count
+
+      expect(attribute_count_after).to eq(attribute_count_before)
+      expect(collection_count_after).to eq(collection_count_before)
+    end
+  end
+end

--- a/spec/lib/sprig/seed/entry_spec.rb
+++ b/spec/lib/sprig/seed/entry_spec.rb
@@ -28,4 +28,18 @@ RSpec.describe Sprig::Seed::Entry do
       end
     end
   end
+
+  describe "sprig_id" do
+    it "uses the explicit 4th constructor argument over any sprig_id present in attrs" do
+      subject = described_class.new(Post, {title: "Hello World!", content: "Stuff", sprig_id: 1}, {}, "explicit-id")
+
+      expect(subject.dependency_id).to eq(Sprig::Dependency.for(Post, "explicit-id").id)
+    end
+
+    it "falls back to attrs' sprig_id when no explicit argument is given" do
+      subject = described_class.new(Post, {title: "Hello World!", content: "Stuff", sprig_id: 1}, {})
+
+      expect(subject.dependency_id).to eq(Sprig::Dependency.for(Post, "1").id)
+    end
+  end
 end

--- a/spec/lib/sprig/seed/factory_spec.rb
+++ b/spec/lib/sprig/seed/factory_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+RSpec.describe Sprig::Seed::Factory do
+  describe "#add_seeds_to_hopper" do
+    let(:hopper) { [] }
+
+    it "pushes a Sprig::Seed::Descriptor (not an Entry) for each datasource record" do
+      datasource = double("datasource", records: [{"sprig_id" => "1", "title" => "Hello"}], options: {})
+      factory = described_class.new(Post, datasource, {})
+
+      factory.add_seeds_to_hopper(hopper)
+
+      expect(hopper.size).to eq(1)
+      expect(hopper.first).to be_a(Sprig::Seed::Descriptor)
+    end
+
+    it "builds each descriptor with the factory's klass and the record's sprig_id" do
+      datasource = double("datasource", records: [{"sprig_id" => "1", "title" => "Hello"}], options: {})
+      factory = described_class.new(Post, datasource, {})
+
+      factory.add_seeds_to_hopper(hopper)
+
+      expect(hopper.first.dependency_id).to eq(Sprig::Dependency.for(Post, "1").id)
+    end
+
+    it "carries the datasource's merged options through so the materialized Entry respects them" do
+      Post.create!(title: "Existing", content: "Content")
+      datasource = double(
+        "datasource",
+        records: [{"sprig_id" => "1", "title" => "Existing", "content" => "Content"}],
+        options: {find_existing_by: [:title]}
+      )
+      factory = described_class.new(Post, datasource, {})
+
+      factory.add_seeds_to_hopper(hopper)
+      entry = hopper.first.to_entry
+      entry.save_record
+
+      expect(entry.success_log_text).to eq("Updated")
+      expect(Post.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
### Ticket

#75 

Resolve Sprig's excessive memory use when loading data.

Changes in this PR: 
- Defer fully "hydrating" seed data into an ActiveRecord instance until the moment before it is actually saved to the database

NOTE: This is Part 2 of 7 Parts.  See the [benchmark/README.md](https://github.com/vigetlabs/sprig/blob/ms/75-resolve-memory-version-3-part-7/benchmark/README.md) file for the complete explanation (it is unchanged across all stacked branches).

NOTE: Most of the content was authored by Claude Sonnet 5 under human supervision. Purely human-authored edits have their own commit.