### PR TITLE
[#75] Resolve Excessive Memory - Part 5 Lazy Load Only

### DIFF
--- a/benchmark/part-5.md
+++ b/benchmark/part-5.md
@@ -1,9 +1,5 @@
 # Part 5: stop retaining full records in `SprigRecordStore`; re-fetch lazily by id
 
-Moved from version-2's `part-2` (where it ran right after the harness, before the
-scheduler) to run here instead, after part 4's incremental scheduler -- with a further
-refinement, the lazy id-only path described below, folded into the same commit.
-
 ## What it does
 
 `sprig_id` is a seed-file-only identifier -- `Entry#initialize` deletes it from a
@@ -23,7 +19,7 @@ real `klass.find(id)`, fetched at most once and memoized, then delegated to.
 
 A live `ActiveRecord`/Mongoid instance is far heavier than the row it represents -- every
 column becomes its own type-cast/dirty-tracking wrapper object. Holding every planted
-record forever, purely so a handful of later references *might* look it up, is a cost
+record forever, purely so a handful of later references _might_ look it up, is a cost
 that grows with the whole dataset regardless of how many records are actually referenced
 again. Re-fetching by id instead means only the id (a bare string-keyed hash entry) is
 retained.
@@ -37,74 +33,12 @@ same as an eager re-fetch would have.
 
 ## Empirical evidence
 
-| Tier | Peak RSS | vs. part-4 | Storage-space-over-time | vs. part-4 |
-|---|---:|---:|---:|---:|
-| Small (1K) | 79.8 MB | -14.7% | 156.8 MB\*s | -6.8% |
-| Medium (10K) | 228.2 MB | **-41.8%** | 4,787.5 MB\*s | **-27.8%** |
-| Large (100K) | 1,232.0 MB | **-39.0%** | 306,955.2 MB\*s | **-58.4%** |
+| Tier         |   Peak RSS | vs. part-4 | Storage-space-over-time | vs. part-4 |
+| ------------ | ---------: | ---------: | ----------------------: | ---------: |
+| Small (1K)   |    79.8 MB |     -14.7% |             156.8 MB\*s |      -6.8% |
+| Medium (10K) |   228.2 MB | **-41.8%** |           4,787.5 MB\*s | **-27.8%** |
+| Large (100K) | 1,232.0 MB | **-39.0%** |         306,955.2 MB\*s | **-58.4%** |
 
 Wall time, part-5 vs. part-4: small 2.019s -> 2.024s (flat); medium 23.47s -> 21.96s
 (**-6.4%**); large 1,143.1s -> 458.5s, a **-59.9% improvement, not a cost** -- the
-wall-time win grows sharply with scale, the mirror image of how version-2's wall-time
-*regression* for this same idea also grew with scale.
-
-### Why this looks completely different from version-2's measurement of the same idea
-
-Version-2 measured this exact change (right after the harness, before the scheduler) as
-a regression that worsened with scale: +4%/+12%/+29% peak RSS and +56%/+77%/+79% wall
-time, small/medium/large. Measured here, after the scheduler, the same underlying idea is
-a substantial win instead. Two separate things account for the full gap between those two
-results:
-
-1. **Position in the stack (the reorder itself).** Under the old whole-graph pipeline
-   (parts 1-3 in this stack), every record and every reference to it stays alive for the
-   entire run regardless of what `SprigRecordStore` does -- the old `Planter`'s
-   `dependency_sorted_seeds` array is memoized and iterated with `#each`, and
-   `Sprig::Seed::Attribute#value` memoizes the raw result of evaluating
-   `<%= sprig_record(Klass, id) %>` for the life of that record's `Entry`. Under
-   hold-forever, every reference to the same id resolves to the *same* shared object, so
-   this costs nothing extra; under re-fetch-by-id, each reference used to construct and
-   permanently pin its own distinct object. That's why re-fetch regressed specifically on
-   the old pipeline, and specifically worse the more cross-references a dataset has --
-   this dataset's `ProjectTag` join is exactly that shape. Under the scheduler (part 4
-   onward), nothing is memoized past the point it's needed, so that permanent-pinning
-   effect doesn't happen in the first place. An earlier pass of this investigation
-   measured the reorder's effect alone (before the fixes below existed): -22.2%/-33.7%
-   peak RSS at small/medium versus part 4, a real win already.
-2. **The lazy id-only path (this commit's own refinement, on top of the reorder).**
-   Fixing part 1's `NULL`-foreign-key bug (see part 1's writeup) exposed that
-   `SprigRecordStore#get` was still doing a full `klass.find(id)` for every single
-   evaluation, immediately discarding everything except the id -- a real, fixable cost
-   that a plain eager re-fetch design still pays even after the reorder. Adding the
-   `LazyRecord` proxy described above eliminates nearly all of the actual database round
-   trips this investigation was originally built around measuring, since this dataset's
-   usage of `sprig_record(...)` is entirely `.id`-only.
-
-Combined, these two changes move the small/medium numbers from -22.2%/-33.7% (reorder
-alone, on the still-buggy dataset) to -14.7%/-41.8% (reorder plus lazy fetch, correct
-dataset) versus part 4 -- **not a smaller effect than initially measured, a larger one**,
-which was flagged as a real risk before this refinement was built: removing the round
-trip's wall-time/GC cost was expected to shrink the interesting story, and instead made
-the underlying "stop holding records forever" benefit show through more clearly. Wall
-time confirms the mechanism directly: this stack's own pre-fix pass measured re-fetch (at
-this position in the stack) costing +49%/+59%/+160% wall time versus part 4
-(small/medium/large); with the round trip mostly eliminated, it's now flat to slightly
-*faster*.
-
-`SprigRecordStore`'s own retained content is confirmed genuinely near-zero either way:
-`store_per_item_bytes` measures 0 for this design in every run, whether or not the lazy
-path is in play -- the difference between the two measurements above is entirely about
-what stays reachable *elsewhere*, not about what this store itself holds.
-
-## Additional notes
-
-The conclusion from all of this isn't "reorder version-2's actual stack" -- that stack is
-left as-is, and a separate, earlier check of literally reordering within that single
-stack found it would obscure other stages' own isolated contributions behind an unrelated
-hold-forever memory tax for several stages, for no real gain (the final, all-parts-
-combined codebase is identical either way, since this change touches only
-`lib/sprig/sprig_record_store.rb` and its own new `lib/sprig/sprig_record_store/
-lazy_record.rb`, which nothing else in either stack depends on). This second stack exists
-specifically to demonstrate, with its own full benchmark run, that this idea's value is
-real and substantial when it runs on top of the scheduler it's actually meant to pair
-with.
+wall-time win grows sharply with scale.

--- a/benchmark/part-5.md
+++ b/benchmark/part-5.md
@@ -1,0 +1,110 @@
+# Part 5: stop retaining full records in `SprigRecordStore`; re-fetch lazily by id
+
+Moved from version-2's `part-2` (where it ran right after the harness, before the
+scheduler) to run here instead, after part 4's incremental scheduler -- with a further
+refinement, the lazy id-only path described below, folded into the same commit.
+
+## What it does
+
+`sprig_id` is a seed-file-only identifier -- `Entry#initialize` deletes it from a
+record's attributes before it's ever saved, so it never becomes a real column, and
+there's no way to look a record back up by `sprig_id` via the database directly.
+`SprigRecordStore#save` used to keep the actual saved record object alive for the rest of
+the run, keyed by class + `sprig_id`, purely so a later `sprig_record(Klass, id)`
+reference could look it up. `#save` now stores just `record.id`.
+
+`#get` returns a `Sprig::SprigRecordStore::LazyRecord` rather than either the old
+in-memory object or an eagerly re-fetched one. `LazyRecord` already knows the id (that's
+all the store ever held) and answers `#id` directly with zero database access; any other
+method call -- an attribute, an association, anything beyond the id -- falls through to a
+real `klass.find(id)`, fetched at most once and memoized, then delegated to.
+
+## How it helps
+
+A live `ActiveRecord`/Mongoid instance is far heavier than the row it represents -- every
+column becomes its own type-cast/dirty-tracking wrapper object. Holding every planted
+record forever, purely so a handful of later references *might* look it up, is a cost
+that grows with the whole dataset regardless of how many records are actually referenced
+again. Re-fetching by id instead means only the id (a bare string-keyed hash entry) is
+retained.
+
+That alone would still cost a database round trip on every `sprig_record(...)`
+evaluation, whether or not the caller needed anything beyond the id. `sprig_record(Klass,
+id)` is overwhelmingly used just to read the id back off for a foreign key
+(`sprig_record(Klass, id).id`) -- exactly the case `LazyRecord` never has to touch the
+database for. Usages that need more than the id still pay for exactly one real fetch,
+same as an eager re-fetch would have.
+
+## Empirical evidence
+
+| Tier | Peak RSS | vs. part-4 | Storage-space-over-time | vs. part-4 |
+|---|---:|---:|---:|---:|
+| Small (1K) | 79.8 MB | -14.7% | 156.8 MB\*s | -6.8% |
+| Medium (10K) | 228.2 MB | **-41.8%** | 4,787.5 MB\*s | **-27.8%** |
+| Large (100K) | 1,232.0 MB | **-39.0%** | 306,955.2 MB\*s | **-58.4%** |
+
+Wall time, part-5 vs. part-4: small 2.019s -> 2.024s (flat); medium 23.47s -> 21.96s
+(**-6.4%**); large 1,143.1s -> 458.5s, a **-59.9% improvement, not a cost** -- the
+wall-time win grows sharply with scale, the mirror image of how version-2's wall-time
+*regression* for this same idea also grew with scale.
+
+### Why this looks completely different from version-2's measurement of the same idea
+
+Version-2 measured this exact change (right after the harness, before the scheduler) as
+a regression that worsened with scale: +4%/+12%/+29% peak RSS and +56%/+77%/+79% wall
+time, small/medium/large. Measured here, after the scheduler, the same underlying idea is
+a substantial win instead. Two separate things account for the full gap between those two
+results:
+
+1. **Position in the stack (the reorder itself).** Under the old whole-graph pipeline
+   (parts 1-3 in this stack), every record and every reference to it stays alive for the
+   entire run regardless of what `SprigRecordStore` does -- the old `Planter`'s
+   `dependency_sorted_seeds` array is memoized and iterated with `#each`, and
+   `Sprig::Seed::Attribute#value` memoizes the raw result of evaluating
+   `<%= sprig_record(Klass, id) %>` for the life of that record's `Entry`. Under
+   hold-forever, every reference to the same id resolves to the *same* shared object, so
+   this costs nothing extra; under re-fetch-by-id, each reference used to construct and
+   permanently pin its own distinct object. That's why re-fetch regressed specifically on
+   the old pipeline, and specifically worse the more cross-references a dataset has --
+   this dataset's `ProjectTag` join is exactly that shape. Under the scheduler (part 4
+   onward), nothing is memoized past the point it's needed, so that permanent-pinning
+   effect doesn't happen in the first place. An earlier pass of this investigation
+   measured the reorder's effect alone (before the fixes below existed): -22.2%/-33.7%
+   peak RSS at small/medium versus part 4, a real win already.
+2. **The lazy id-only path (this commit's own refinement, on top of the reorder).**
+   Fixing part 1's `NULL`-foreign-key bug (see part 1's writeup) exposed that
+   `SprigRecordStore#get` was still doing a full `klass.find(id)` for every single
+   evaluation, immediately discarding everything except the id -- a real, fixable cost
+   that a plain eager re-fetch design still pays even after the reorder. Adding the
+   `LazyRecord` proxy described above eliminates nearly all of the actual database round
+   trips this investigation was originally built around measuring, since this dataset's
+   usage of `sprig_record(...)` is entirely `.id`-only.
+
+Combined, these two changes move the small/medium numbers from -22.2%/-33.7% (reorder
+alone, on the still-buggy dataset) to -14.7%/-41.8% (reorder plus lazy fetch, correct
+dataset) versus part 4 -- **not a smaller effect than initially measured, a larger one**,
+which was flagged as a real risk before this refinement was built: removing the round
+trip's wall-time/GC cost was expected to shrink the interesting story, and instead made
+the underlying "stop holding records forever" benefit show through more clearly. Wall
+time confirms the mechanism directly: this stack's own pre-fix pass measured re-fetch (at
+this position in the stack) costing +49%/+59%/+160% wall time versus part 4
+(small/medium/large); with the round trip mostly eliminated, it's now flat to slightly
+*faster*.
+
+`SprigRecordStore`'s own retained content is confirmed genuinely near-zero either way:
+`store_per_item_bytes` measures 0 for this design in every run, whether or not the lazy
+path is in play -- the difference between the two measurements above is entirely about
+what stays reachable *elsewhere*, not about what this store itself holds.
+
+## Additional notes
+
+The conclusion from all of this isn't "reorder version-2's actual stack" -- that stack is
+left as-is, and a separate, earlier check of literally reordering within that single
+stack found it would obscure other stages' own isolated contributions behind an unrelated
+hold-forever memory tax for several stages, for no real gain (the final, all-parts-
+combined codebase is identical either way, since this change touches only
+`lib/sprig/sprig_record_store.rb` and its own new `lib/sprig/sprig_record_store/
+lazy_record.rb`, which nothing else in either stack depends on). This second stack exists
+specifically to demonstrate, with its own full benchmark run, that this idea's value is
+real and substantial when it runs on top of the scheduler it's actually meant to pair
+with.

--- a/lib/sprig/sprig_record_store.rb
+++ b/lib/sprig/sprig_record_store.rb
@@ -10,23 +10,15 @@ module Sprig
 
     class RecordNotFoundError < StandardError; end
 
-    # sprig_id is a seed-file-only identifier -- Entry#initialize deletes it from a
-    # record's attributes before it's ever saved, so it never becomes a real column,
-    # and there's no way to look a record back up by sprig_id via the database
-    # directly. What's kept here is only enough to bridge that gap: the record's
-    # real primary key. The record itself is never held in memory for the whole
-    # run -- a live ActiveRecord/Mongoid instance is far larger than the row it
-    # represents (every column becomes its own type-cast/dirty-tracking wrapper
-    # object).
+    # sprig_id is a seed-file-only identifier, never saved to the database, so 
+    # we need to track the mapping between sprig_id and the record's actual id.
     def save(record, sprig_id)
       records_of_klass(record.class)[sprig_id.to_s] = record.id
     end
 
-    # Returns a LazyRecord, not a fetched record -- #get itself never queries the
-    # database. sprig_record(Klass, id) is overwhelmingly used just to read the id
-    # back off (setting a foreign key), and the id is already sitting right here;
-    # LazyRecord answers that directly, and only falls through to a real
-    # klass.find(id) if something beyond the id is actually asked of it.
+    # Since the majority of get calls will be for the id, we return a LazyRecord that
+    # answers id directly without a database call (any other attributes still work but
+    # will trigger a database fetch).
     def get(klass, sprig_id)
       id = records_of_klass(klass)[sprig_id.to_s] || record_not_found(klass, sprig_id)
       LazyRecord.new(klass, id)

--- a/lib/sprig/sprig_record_store.rb
+++ b/lib/sprig/sprig_record_store.rb
@@ -10,12 +10,26 @@ module Sprig
 
     class RecordNotFoundError < StandardError; end
 
+    # sprig_id is a seed-file-only identifier -- Entry#initialize deletes it from a
+    # record's attributes before it's ever saved, so it never becomes a real column,
+    # and there's no way to look a record back up by sprig_id via the database
+    # directly. What's kept here is only enough to bridge that gap: the record's
+    # real primary key. The record itself is never held in memory for the whole
+    # run -- a live ActiveRecord/Mongoid instance is far larger than the row it
+    # represents (every column becomes its own type-cast/dirty-tracking wrapper
+    # object).
     def save(record, sprig_id)
-      records_of_klass(record.class)[sprig_id.to_s] = record
+      records_of_klass(record.class)[sprig_id.to_s] = record.id
     end
 
+    # Returns a LazyRecord, not a fetched record -- #get itself never queries the
+    # database. sprig_record(Klass, id) is overwhelmingly used just to read the id
+    # back off (setting a foreign key), and the id is already sitting right here;
+    # LazyRecord answers that directly, and only falls through to a real
+    # klass.find(id) if something beyond the id is actually asked of it.
     def get(klass, sprig_id)
-      records_of_klass(klass)[sprig_id.to_s] || record_not_found(klass, sprig_id)
+      id = records_of_klass(klass)[sprig_id.to_s] || record_not_found(klass, sprig_id)
+      LazyRecord.new(klass, id)
     end
 
     def reset
@@ -37,3 +51,5 @@ module Sprig
     end
   end
 end
+
+require_relative "sprig_record_store/lazy_record"

--- a/lib/sprig/sprig_record_store/lazy_record.rb
+++ b/lib/sprig/sprig_record_store/lazy_record.rb
@@ -1,0 +1,47 @@
+module Sprig
+  class SprigRecordStore
+    # What #get hands back for a saved sprig_id: the id itself, answered directly
+    # with no database access, since that's all SprigRecordStore ever held onto.
+    # Any other call -- an attribute, an association, anything beyond the id --
+    # falls through to a real klass.find(id), fetched at most once and memoized,
+    # then delegated to. sprig_record(Klass, id) usages that only ever need the id
+    # (by far the common case -- setting a foreign key) never touch the database
+    # at all; usages that need more than the id pay for exactly one real fetch,
+    # same as before.
+    #
+    # Known limitation: this responds to arbitrary methods via delegation, but
+    # #is_a?/#kind_of?/#instance_of? report LazyRecord's own class, not the
+    # wrapped record's -- code that type-checks a sprig_record(...) result against
+    # the model class directly (rather than calling a method on it) would need to
+    # go through #to_real_record first.
+    class LazyRecord
+      attr_reader :id
+
+      def initialize(klass, id)
+        @klass = klass
+        @id = id
+      end
+
+      def to_real_record
+        @real_record ||= @klass.find(@id)
+      end
+
+      def ==(other)
+        to_real_record == other
+      end
+      alias_method :eql?, :==
+
+      def hash
+        to_real_record.hash
+      end
+
+      def method_missing(name, *args, &block)
+        to_real_record.public_send(name, *args, &block)
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        to_real_record.respond_to?(name, include_private)
+      end
+    end
+  end
+end

--- a/lib/sprig/sprig_record_store/lazy_record.rb
+++ b/lib/sprig/sprig_record_store/lazy_record.rb
@@ -1,13 +1,9 @@
 module Sprig
   class SprigRecordStore
-    # What #get hands back for a saved sprig_id: the id itself, answered directly
-    # with no database access, since that's all SprigRecordStore ever held onto.
-    # Any other call -- an attribute, an association, anything beyond the id --
-    # falls through to a real klass.find(id), fetched at most once and memoized,
-    # then delegated to. sprig_record(Klass, id) usages that only ever need the id
-    # (by far the common case -- setting a foreign key) never touch the database
-    # at all; usages that need more than the id pay for exactly one real fetch,
-    # same as before.
+    # Given that the overwhelming majority of references to a sprig_record are for
+    # the id, we allow responding to sprig_record.id without a database call; a #get
+    # for any other attribute/method will result in an actual database fetch,
+    # memoized for the lifetime of the LazyRecord instance.
     #
     # Known limitation: this responds to arbitrary methods via delegation, but
     # #is_a?/#kind_of?/#instance_of? report LazyRecord's own class, not the

--- a/spec/lib/sprig/sprig_record_store/lazy_record_spec.rb
+++ b/spec/lib/sprig/sprig_record_store/lazy_record_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+RSpec.describe Sprig::SprigRecordStore::LazyRecord do
+  describe "#id" do
+    it "returns the wrapped id without querying the database" do
+      expect(Post).not_to receive(:find)
+
+      lazy = described_class.new(Post, 42)
+
+      expect(lazy.id).to eq(42)
+    end
+  end
+
+  describe "delegation" do
+    it "fetches the real record and delegates a method not defined on LazyRecord itself" do
+      post = Post.create!(title: "Hello", content: "World")
+
+      lazy = described_class.new(Post, post.id)
+
+      expect(lazy.title).to eq("Hello")
+    end
+
+    it "fetches at most once, even if multiple delegated methods are called" do
+      post = Post.create!(title: "Hello", content: "World")
+      lazy = described_class.new(Post, post.id)
+
+      expect(Post).to receive(:find).once.and_call_original
+
+      lazy.title
+      lazy.content
+    end
+
+    it "raises whatever the underlying finder raises for an id that doesn't exist" do
+      lazy = described_class.new(Post, -1)
+
+      # The specific error class is adapter-dependent (ActiveRecord::RecordNotFound
+      # vs. Mongoid::Errors::DocumentNotFound) -- LazyRecord doesn't rescue or
+      # translate it, so this only checks that #find's own error propagates.
+      expect { lazy.title }.to raise_error(StandardError)
+    end
+  end
+
+  describe "#==" do
+    it "compares equal to the real record it wraps" do
+      post = Post.create!(title: "Hello", content: "World")
+      lazy = described_class.new(Post, post.id)
+
+      expect(lazy).to eq(post)
+    end
+
+    it "does not equal a different record" do
+      post = Post.create!(title: "Hello", content: "World")
+      other = Post.create!(title: "Other", content: "Content")
+      lazy = described_class.new(Post, post.id)
+
+      expect(lazy).not_to eq(other)
+    end
+  end
+
+  describe "#respond_to?" do
+    it "reports true for the wrapped record's own attributes" do
+      post = Post.create!(title: "Hello", content: "World")
+      lazy = described_class.new(Post, post.id)
+
+      expect(lazy).to respond_to(:title)
+    end
+  end
+end

--- a/spec/lib/sprig/sprig_record_store_spec.rb
+++ b/spec/lib/sprig/sprig_record_store_spec.rb
@@ -1,0 +1,97 @@
+require "spec_helper"
+
+RSpec.describe Sprig::SprigRecordStore do
+  subject { described_class.instance }
+
+  before { subject.reset }
+
+  describe "#save / #get" do
+    it "returns a record with the correct attributes for a saved sprig_id" do
+      post = Post.create!(title: "Hello", content: "World")
+
+      subject.save(post, "1")
+
+      fetched = subject.get(Post, "1")
+      expect(fetched.title).to eq("Hello")
+      expect(fetched.content).to eq("World")
+    end
+
+    it "does not retain the record instance itself -- only enough to look it back up" do
+      post = Post.create!(title: "Hello", content: "World")
+
+      subject.save(post, "1")
+
+      stored = subject.instance_variable_get(:@records)["posts"]["1"]
+      expect(stored).not_to be_a(Post)
+      expect(stored).to eq(post.id)
+    end
+
+    it "returns a LazyRecord, not a freshly-fetched real record or the original instance" do
+      post = Post.create!(title: "Hello", content: "World")
+      subject.save(post, "1")
+
+      fetched = subject.get(Post, "1")
+
+      expect(fetched).to be_a(Sprig::SprigRecordStore::LazyRecord)
+      expect(fetched).not_to equal(post)
+      expect(fetched).to eq(post)
+    end
+
+    it "reflects updates made to the database after saving, since it re-fetches on every call" do
+      post = Post.create!(title: "Hello", content: "World")
+      subject.save(post, "1")
+
+      post.update!(title: "Updated")
+
+      expect(subject.get(Post, "1").title).to eq("Updated")
+    end
+
+    it "stores multiple records independently, keyed by class and sprig_id" do
+      post = Post.create!(title: "A Post")
+      user = User.create!(first_name: "Ada", last_name: "Lovelace")
+
+      subject.save(post, "1")
+      subject.save(user, "1")
+
+      expect(subject.get(Post, "1")).to eq(post)
+      expect(subject.get(User, "1")).to eq(user)
+    end
+
+    it "raises RecordNotFoundError for a sprig_id that was never saved" do
+      expect {
+        subject.get(Post, "999")
+      }.to raise_error(Sprig::SprigRecordStore::RecordNotFoundError)
+    end
+
+    it "answers #id directly with no database fetch" do
+      post = Post.create!(title: "Hello", content: "World")
+      subject.save(post, "1")
+
+      expect(Post).not_to receive(:find)
+      expect(subject.get(Post, "1").id).to eq(post.id)
+    end
+
+    it "fetches the real record, exactly once, only when something beyond the id is asked for" do
+      post = Post.create!(title: "Hello", content: "World")
+      subject.save(post, "1")
+
+      expect(Post).to receive(:find).once.and_call_original
+      fetched = subject.get(Post, "1")
+      fetched.title
+      fetched.content
+    end
+  end
+
+  describe "#reset" do
+    it "clears previously saved records" do
+      post = Post.create!(title: "Hello")
+      subject.save(post, "1")
+
+      subject.reset
+
+      expect {
+        subject.get(Post, "1")
+      }.to raise_error(Sprig::SprigRecordStore::RecordNotFoundError)
+    end
+  end
+end


### PR DESCRIPTION
### Ticket

#75 

Resolve Sprig's excessive memory use when loading data.

Changes in this PR:
- Stop Retaining full records indefinitely
- Lazy load attributes other than ID when required

NOTE: This is Part 5 of 7 Parts.  See the [benchmark/README.md](https://github.com/vigetlabs/sprig/blob/ms/75-resolve-memory-version-3-part-7/benchmark/README.md) file for the complete explanation (it is unchanged across all stacked branches).

NOTE: Most of the content was authored by Claude Sonnet 5 under human supervision. Purely human-authored edits have their own commit.