### PR TITLE
[#75] Resolve Excessive Memory - Part 6 Stream Files from Disk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     sprig (0.3.1)
       csv (~> 3.3)
+      oj (~> 3.16)
 
 GEM
   remote: https://rubygems.org/
@@ -153,6 +154,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
+    oj (3.17.6)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
+    ostruct (0.6.3)
     parallel (2.1.0)
     parser (3.3.12.0)
       ast (~> 2.4.1)

--- a/benchmark/part-6.md
+++ b/benchmark/part-6.md
@@ -1,0 +1,57 @@
+# Part 6: stream YAML/JSON parsing directly off IO instead of loading whole file
+
+Port of the parser half (Option D) of the original investigation's `986bbad`, split from
+that commit's other, independent halves (dependency-retention fixes -> this stack's part
+3; opt-in disk spill -> part 7).
+
+## What it does
+
+`Parser::Yml`/`Json` no longer fully parse a file into memory via
+`YAML.load`/`JSON.load`. Each now runs a `Psych::Parser`/`Oj::ScHandler` callback handler
+(new `EventHandler` classes) that reads directly off the source `IO`, rewinding between
+an eager pass that captures `options:` (small, cheap to build fully) and a lazy pass --
+deferred until the returned `Enumerator` is actually iterated -- that streams `records:`
+one row at a time, matching by key name (not position) since `options:`/`records:` can
+appear in either order. `Parser::Csv` reverted to streaming `CSV.foreach` directly. This
+only works because `Source#data` no longer closes the IO the instant `#parse` returns --
+it now closes once the records enumerator is actually exhausted (or parsing fails).
+Non-rewindable custom `:source` IOs (a real pipe, verified against `Errno::ESPIPE` on
+`#rewind`) fall back to buffering once, same as before. Adds `oj` as a runtime dependency.
+
+## How it helps
+
+`YAML.load(data_io)` builds the *entire* parsed file -- every row of every one of the 5
+models -- as one big nested Ruby structure before `Factory` ever converts the first row
+into a `Descriptor`. That whole intermediate structure is gone once parsing streams a row
+at a time straight into `Descriptor` construction. This effect scales with file size,
+which is exactly why it's modest at 1K and dominant at 10K/100K.
+
+## Empirical evidence
+
+| Tier | Peak RSS | vs. part-5 | Storage-space-over-time | vs. part-5 |
+|---|---:|---:|---:|---:|
+| Small (1K) | 75.3 MB | -5.6% | 148.2 MB\*s | -5.5% |
+| Medium (10K) | 115.2 MB | **-49.5%** | 2,652.0 MB\*s | **-44.6%** |
+| Large (100K) | 509.0 MB | **-58.7%** | 138,504.7 MB\*s | **-54.9%** |
+
+**This is the single largest contributor of any stage in this stack at medium scale**,
+substantially larger than the original investigation's own ranking suggested, where it
+was measured only in combination with the dependency-retention fixes and characterized as
+mattering mainly for very large single files. Cumulative against the part-1 baseline,
+this stage alone accounts for the majority of this stack's total medium-tier reduction.
+
+## Additional notes
+
+At the time this stage was ported, the full spec suite passed on the default config (201
+examples) and all five Appraisals (rails-7.2/8.0/8.1, mongoid-8/9); standardrb clean.
+`lib/sprig/{parser,source}.rb` and `sprig.gemspec` were untouched by every commit
+`master` gained after the original investigation branched, so this was a clean, direct
+port needing no integration work -- unlike parts 2 and 4, which both needed real
+adaptation for `master`'s transactional `Planter`.
+
+The medium-tier drop was confirmed reproducible, not a one-off outlier, across repeated
+runs at that tier in an earlier pass of this investigation (part 5 in the ~215-276 MB
+range, this stage in the ~125-133 MB range, non-overlapping) before the fixes described
+in part 1/5's writeups landed -- the magnitude has since changed with the corrected
+dataset, but the non-overlapping, reproducible-across-repeats character of the drop was
+established directly, not assumed from a single run.

--- a/benchmark/part-6.md
+++ b/benchmark/part-6.md
@@ -1,9 +1,5 @@
 # Part 6: stream YAML/JSON parsing directly off IO instead of loading whole file
 
-Port of the parser half (Option D) of the original investigation's `986bbad`, split from
-that commit's other, independent halves (dependency-retention fixes -> this stack's part
-3; opt-in disk spill -> part 7).
-
 ## What it does
 
 `Parser::Yml`/`Json` no longer fully parse a file into memory via
@@ -20,7 +16,7 @@ Non-rewindable custom `:source` IOs (a real pipe, verified against `Errno::ESPIP
 
 ## How it helps
 
-`YAML.load(data_io)` builds the *entire* parsed file -- every row of every one of the 5
+`YAML.load(data_io)` builds the _entire_ parsed file -- every row of every one of the 5
 models -- as one big nested Ruby structure before `Factory` ever converts the first row
 into a `Descriptor`. That whole intermediate structure is gone once parsing streams a row
 at a time straight into `Descriptor` construction. This effect scales with file size,
@@ -28,30 +24,11 @@ which is exactly why it's modest at 1K and dominant at 10K/100K.
 
 ## Empirical evidence
 
-| Tier | Peak RSS | vs. part-5 | Storage-space-over-time | vs. part-5 |
-|---|---:|---:|---:|---:|
-| Small (1K) | 75.3 MB | -5.6% | 148.2 MB\*s | -5.5% |
-| Medium (10K) | 115.2 MB | **-49.5%** | 2,652.0 MB\*s | **-44.6%** |
-| Large (100K) | 509.0 MB | **-58.7%** | 138,504.7 MB\*s | **-54.9%** |
+| Tier         | Peak RSS | vs. part-5 | Storage-space-over-time | vs. part-5 |
+| ------------ | -------: | ---------: | ----------------------: | ---------: |
+| Small (1K)   |  75.3 MB |      -5.6% |             148.2 MB\*s |      -5.5% |
+| Medium (10K) | 115.2 MB | **-49.5%** |           2,652.0 MB\*s | **-44.6%** |
+| Large (100K) | 509.0 MB | **-58.7%** |         138,504.7 MB\*s | **-54.9%** |
 
-**This is the single largest contributor of any stage in this stack at medium scale**,
-substantially larger than the original investigation's own ranking suggested, where it
-was measured only in combination with the dependency-retention fixes and characterized as
-mattering mainly for very large single files. Cumulative against the part-1 baseline,
+**This is the single largest contributor of any stage in this stack at medium scale.** Cumulative against the part-1 baseline,
 this stage alone accounts for the majority of this stack's total medium-tier reduction.
-
-## Additional notes
-
-At the time this stage was ported, the full spec suite passed on the default config (201
-examples) and all five Appraisals (rails-7.2/8.0/8.1, mongoid-8/9); standardrb clean.
-`lib/sprig/{parser,source}.rb` and `sprig.gemspec` were untouched by every commit
-`master` gained after the original investigation branched, so this was a clean, direct
-port needing no integration work -- unlike parts 2 and 4, which both needed real
-adaptation for `master`'s transactional `Planter`.
-
-The medium-tier drop was confirmed reproducible, not a one-off outlier, across repeated
-runs at that tier in an earlier pass of this investigation (part 5 in the ~215-276 MB
-range, this stage in the ~125-133 MB range, non-overlapping) before the fixes described
-in part 1/5's writeups landed -- the magnitude has since changed with the corrected
-dataset, but the non-overlapping, reproducible-across-repeats character of the drop was
-established directly, not assumed from a single run.

--- a/lib/sprig/parser/csv.rb
+++ b/lib/sprig/parser/csv.rb
@@ -3,9 +3,7 @@ require "csv"
 module Sprig
   module Parser
     class Csv < Base
-      # CSV has no options:/records: sibling-key structure to worry about, and
-      # Source#data no longer closes data_io until this enumerator is exhausted, so
-      # this can stream directly off data_io via CSV.foreach -- no buffering of the
+      # Stream directly off data_io via CSV.foreach -- no buffering of the
       # file into memory at all.
       def parse
         {records: Enumerator.new { |yielder| stream_records { |row| yielder << row } }}

--- a/lib/sprig/parser/csv.rb
+++ b/lib/sprig/parser/csv.rb
@@ -3,17 +3,19 @@ require "csv"
 module Sprig
   module Parser
     class Csv < Base
+      # CSV has no options:/records: sibling-key structure to worry about, and
+      # Source#data no longer closes data_io until this enumerator is exhausted, so
+      # this can stream directly off data_io via CSV.foreach -- no buffering of the
+      # file into memory at all.
       def parse
-        {records: records}
+        {records: Enumerator.new { |yielder| stream_records { |row| yielder << row } }}
       end
 
       private
 
-      def records
-        [].tap do |records|
-          CSV.foreach(data_io, headers: :first_row, skip_blanks: true) do |row|
-            records << row.to_hash
-          end
+      def stream_records(&block)
+        CSV.foreach(data_io, headers: :first_row, skip_blanks: true) do |row|
+          block.call(row.to_hash)
         end
       end
     end

--- a/lib/sprig/parser/json.rb
+++ b/lib/sprig/parser/json.rb
@@ -1,9 +1,47 @@
+require "oj"
+
 module Sprig
   module Parser
     class Json < Base
+      RECORDS_KEY = "records"
+      OPTIONS_KEY = "options"
+
+      # See Sprig::Parser::Yml#parse for the reasoning: two passes are required
+      # (options captured eagerly, records streamed lazily) regardless of key order in
+      # the file, and both read directly from data_io when it's rewindable so peak
+      # memory never scales with file size -- falling back to a one-time buffered read
+      # only for non-rewindable custom sources.
       def parse
-        JSON.load(data_io) # rubocop:disable Security/JSONLoad
+        input = rewindable? ? data_io : data_io.read
+
+        {
+          options: capture_options(input) || {},
+          records: Enumerator.new { |yielder| stream_records(input) { |row| yielder << row } }
+        }
+      end
+
+      private
+
+      def rewindable?
+        data_io.rewind
+        true
+      rescue IOError, Errno::ESPIPE, NotImplementedError
+        false
+      end
+
+      def capture_options(input)
+        handler = EventHandler.new(capture_key: OPTIONS_KEY)
+        Oj.sc_parse(handler, input)
+        data_io.rewind if input.equal?(data_io)
+        handler.capture_value
+      end
+
+      def stream_records(input, &block)
+        handler = EventHandler.new(stream_key: RECORDS_KEY, &block)
+        Oj.sc_parse(handler, input)
       end
     end
   end
 end
+
+require_relative "json/event_handler"

--- a/lib/sprig/parser/json/event_handler.rb
+++ b/lib/sprig/parser/json/event_handler.rb
@@ -1,0 +1,77 @@
+require "oj"
+
+module Sprig
+  module Parser
+    class Json
+      # An Oj::ScHandler that, for two named top-level keys, either fully
+      # materializes that key's value into a plain Ruby object ("capture", used
+      # for `options`) or yields each element of that key's array value one at a
+      # time via a block ("stream", used for `records`) -- without ever building
+      # the full array. Oj already builds nested Ruby structures incrementally via
+      # these callbacks, so the only extra bookkeeping needed here is: (a) tracking
+      # depth so only the *root* `options`/`records` keys are matched, not a
+      # same-named field nested inside a record, and (b) recognizing "the array
+      # that's the value of the streamed key" by object identity via a sentinel,
+      # so array_append can redirect to the block instead of growing a real array.
+      #
+      # Keys are matched by name, not position: `options`/`records` can appear in
+      # either order, and an option's own value (e.g. find_existing_by: [...])
+      # can itself be an array.
+      class EventHandler < Oj::ScHandler
+        def initialize(capture_key: nil, stream_key: nil, &on_streamed_row)
+          super()
+          @capture_key = capture_key
+          @stream_key = stream_key
+          @on_streamed_row = on_streamed_row
+
+          @depth = 0
+          @awaiting_key = nil
+          @stream_marker = nil
+          @capture_value = nil
+        end
+
+        attr_reader :capture_value
+
+        def hash_start
+          @depth += 1
+          {}
+        end
+
+        def hash_end
+          @depth -= 1
+        end
+
+        def hash_key(key)
+          @awaiting_key = key if @depth == 1
+          key
+        end
+
+        def hash_set(h, key, value)
+          @capture_value = value if @depth == 1 && @capture_key && key == @capture_key
+          h[key] = value unless value.equal?(@stream_marker)
+        end
+
+        def array_start
+          @depth += 1
+          if @stream_key && @awaiting_key == @stream_key && @stream_marker.nil?
+            @stream_marker = Object.new.freeze
+          else
+            []
+          end
+        end
+
+        def array_end
+          @depth -= 1
+        end
+
+        def array_append(array, value)
+          if array.equal?(@stream_marker)
+            @on_streamed_row.call(value)
+          else
+            array << value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sprig/parser/yml.rb
+++ b/lib/sprig/parser/yml.rb
@@ -1,9 +1,56 @@
+require "psych"
+
 module Sprig
   module Parser
     class Yml < Base
+      RECORDS_KEY = "records"
+      OPTIONS_KEY = "options"
+
+      # `options:` and `records:` are sibling keys that can appear in either order, and
+      # Factory needs options fully resolved before it processes the first record -- so
+      # this always takes two full passes: one that fully captures `options:` (small, so
+      # cheap to build eagerly), and one -- deferred until the returned Enumerator is
+      # actually iterated -- that streams `records:` one row at a time, never building
+      # the full array.
+      #
+      # When data_io is rewindable (a real file, StringIO, anything seekable -- the
+      # common case), both passes read directly from it, so peak memory never scales
+      # with file size, only with one row at a time. Source#data only closes data_io
+      # once the records enumerator is exhausted, so it's safe for this second pass to
+      # stay deferred. When data_io can't be rewound (e.g. a one-shot custom :source
+      # like a pipe or network stream), this falls back to reading the whole file into
+      # a string once and running both passes against that instead.
       def parse
-        YAML.load(data_io)
+        input = rewindable? ? data_io : data_io.read
+
+        {
+          options: capture_options(input) || {},
+          records: Enumerator.new { |yielder| stream_records(input) { |row| yielder << row } }
+        }
+      end
+
+      private
+
+      def rewindable?
+        data_io.rewind
+        true
+      rescue IOError, Errno::ESPIPE, NotImplementedError
+        false
+      end
+
+      def capture_options(input)
+        handler = EventHandler.new(capture_key: OPTIONS_KEY)
+        Psych::Parser.new(handler).parse(input)
+        data_io.rewind if input.equal?(data_io)
+        handler.capture_value
+      end
+
+      def stream_records(input, &block)
+        handler = EventHandler.new(stream_key: RECORDS_KEY, &block)
+        Psych::Parser.new(handler).parse(input)
       end
     end
   end
 end
+
+require_relative "yml/event_handler"

--- a/lib/sprig/parser/yml/event_handler.rb
+++ b/lib/sprig/parser/yml/event_handler.rb
@@ -1,0 +1,126 @@
+require "psych"
+
+module Sprig
+  module Parser
+    class Yml
+      # Walks a YAML document once via Psych::Parser and, for two named top-level
+      # keys, either fully materializes that key's value into a plain Ruby object
+      # ("capture", used for `options:`) or yields each element of that key's
+      # sequence value one at a time via a block ("stream", used for `records:`)
+      # without ever building the full sequence in memory.
+      #
+      # Keys are matched by name, not by position or "the first sequence
+      # encountered" -- `options:`/`records:` can appear in either order, and an
+      # option's own value (e.g. find_existing_by: [...]) can itself be an array,
+      # so position/shape alone can't tell them apart.
+      #
+      # Assumes the shape Sprig's seed files actually use: the captured key's
+      # value is a single node (a mapping, in practice), and the streamed key's
+      # value is a sequence of mappings (one per record).
+      class EventHandler < Psych::Handler
+        def initialize(capture_key: nil, stream_key: nil, &on_streamed_row)
+          @capture_key = capture_key
+          @stream_key = stream_key
+          @on_streamed_row = on_streamed_row
+
+          @depth = 0
+          @pending_key = nil
+          @stream_depth = nil
+
+          @builder = nil
+          @builder_mode = nil
+          @builder_close_depth = nil
+        end
+
+        attr_reader :capture_value
+
+        def start_mapping(anchor, tag, implicit, style)
+          before_entering_node!
+          @depth += 1
+          @builder&.start_mapping(anchor, tag, implicit, style)
+        end
+
+        def end_mapping
+          @builder&.end_mapping
+          @depth -= 1
+          finish_builder_if_done
+        end
+
+        def start_sequence(anchor, tag, implicit, style)
+          before_entering_node!
+          @depth += 1
+          @builder&.start_sequence(anchor, tag, implicit, style)
+        end
+
+        def end_sequence
+          @builder&.end_sequence
+          @depth -= 1
+          finish_builder_if_done
+        end
+
+        def scalar(value, anchor, tag, plain, quoted, style)
+          if @builder
+            @builder.scalar(value, anchor, tag, plain, quoted, style)
+          elsif @depth == 1
+            @pending_key = value
+          end
+        end
+
+        def alias(anchor)
+          @builder&.alias(anchor)
+        end
+
+        private
+
+        # Called before descending into any new mapping/sequence node. Decides
+        # whether this node is the value of a key we care about.
+        def before_entering_node!
+          return if @builder
+
+          if @depth == 1 && @pending_key
+            claim_pending_key!
+          elsif @stream_depth && @depth == @stream_depth
+            start_builder(:stream_row)
+          end
+        end
+
+        def claim_pending_key!
+          if @capture_key && @pending_key == @capture_key
+            start_builder(:capture)
+          elsif @stream_key && @pending_key == @stream_key
+            @stream_depth = @depth + 1
+          end
+          @pending_key = nil
+        end
+
+        def start_builder(mode)
+          @builder = Psych::TreeBuilder.new
+          @builder.start_stream(Psych::Nodes::Stream::UTF8)
+          @builder.start_document([1, 1], [], true)
+          @builder_mode = mode
+          @builder_close_depth = @depth
+        end
+
+        def finish_builder_if_done
+          return unless @builder && @depth == @builder_close_depth
+
+          @builder.end_document
+          @builder.end_stream
+          document_node = @builder.root.children.first
+          value_node = document_node.children.first
+          ruby_value = value_node.to_ruby
+
+          if @builder_mode == :capture
+            @capture_value = ruby_value
+          else
+            @on_streamed_row.call(ruby_value)
+          end
+
+          @builder = nil
+          @builder_mode = nil
+          @builder_close_depth = nil
+        end
+      end
+    end
+  end
+end

--- a/lib/sprig/source.rb
+++ b/lib/sprig/source.rb
@@ -5,8 +5,16 @@ module Sprig
       @args = args
     end
 
+    # The source IO deliberately stays open past this method returning -- closing it
+    # happens once the records enumerator below is actually exhausted, since some
+    # parsers (Yml, Json) defer part of their own parsing until #records is iterated,
+    # and can't do that off an already-closed IO.
     def records
-      data[:records] || []
+      @records ||= Enumerator.new do |yielder|
+        (data[:records] || []).each { |row| yielder << row }
+      ensure
+        source.close
+      end
     end
 
     def options
@@ -20,8 +28,9 @@ module Sprig
     def data
       @data ||= begin
         parser_class.new(source).parse.to_hash.with_indifferent_access
-      ensure
+      rescue
         source.close
+        raise
       end
     end
 

--- a/spec/lib/sprig/parser/csv_spec.rb
+++ b/spec/lib/sprig/parser/csv_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+RSpec.describe Sprig::Parser::Csv do
+  describe "#parse" do
+    it "matches a plain CSV.foreach parse of the same file" do
+      file = File.open("spec/fixtures/seeds/test/posts.csv")
+      expected = CSV.foreach("spec/fixtures/seeds/test/posts.csv", headers: :first_row, skip_blanks: true).map(&:to_hash)
+
+      result = described_class.new(file).parse
+
+      expect(result[:records].to_a).to eq(expected)
+      file.close
+    end
+
+    it "returns records as an Enumerator, not a realized Array" do
+      file = File.open("spec/fixtures/seeds/test/posts.csv")
+
+      result = described_class.new(file).parse
+
+      expect(result[:records]).to be_an(Enumerator)
+      file.close
+    end
+
+    it "iterates records correctly even after the original IO has been closed" do
+      file = File.open("spec/fixtures/seeds/test/posts.csv")
+      expected = CSV.foreach("spec/fixtures/seeds/test/posts.csv", headers: :first_row, skip_blanks: true).map(&:to_hash)
+
+      result = described_class.new(file).parse
+      file.close
+
+      expect(result[:records].to_a).to eq(expected)
+    end
+
+    it "skips blank lines, matching today's behavior" do
+      content = "sprig_id,title\n1,First\n\n2,Second\n"
+      file = StringIO.new(content)
+
+      result = described_class.new(file).parse
+
+      expect(result[:records].to_a).to eq([{"sprig_id" => "1", "title" => "First"}, {"sprig_id" => "2", "title" => "Second"}])
+    end
+  end
+end

--- a/spec/lib/sprig/parser/json_spec.rb
+++ b/spec/lib/sprig/parser/json_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+RSpec.describe Sprig::Parser::Json do
+  describe "#parse" do
+    it "matches JSON.load for a simple records-only file" do
+      file = File.open("spec/fixtures/seeds/test/posts.json")
+      expected = JSON.load_file("spec/fixtures/seeds/test/posts.json")
+
+      result = described_class.new(file).parse
+
+      expect(result[:records].to_a).to eq(expected["records"])
+      file.close
+    end
+
+    it "matches JSON.load when options (with an array-valued suboption) appears before records" do
+      data = <<~JSON
+        {
+          "options": {"find_existing_by": ["title", "content"]},
+          "records": [
+            {"sprig_id": 1, "title": "Such Title"},
+            {"sprig_id": 2, "title": "Other Title"}
+          ]
+        }
+      JSON
+      expected = JSON.parse(data)
+
+      result = described_class.new(StringIO.new(data)).parse
+
+      expect(result[:options]).to eq(expected["options"])
+      expect(result[:records].to_a).to eq(expected["records"])
+    end
+
+    it "matches JSON.load for a record with a nested array attribute" do
+      data = <<~JSON
+        {
+          "records": [
+            {"sprig_id": 1, "title": "A", "tags": ["x", "y"]}
+          ],
+          "options": {"delete_existing_by": "title"}
+        }
+      JSON
+      expected = JSON.parse(data)
+
+      result = described_class.new(StringIO.new(data)).parse
+
+      expect(result[:records].to_a).to eq(expected["records"])
+      expect(result[:options]).to eq(expected["options"])
+    end
+
+    it "returns an empty hash for options when the file has none" do
+      file = File.open("spec/fixtures/seeds/test/posts.json")
+
+      result = described_class.new(file).parse
+
+      expect(result[:options]).to eq({})
+      file.close
+    end
+
+    it "returns records as an Enumerator, not a realized Array" do
+      file = File.open("spec/fixtures/seeds/test/posts.json")
+
+      result = described_class.new(file).parse
+
+      expect(result[:records]).to be_an(Enumerator)
+      file.close
+    end
+
+    it "falls back to buffering the whole file when data_io is not rewindable (e.g. a pipe)" do
+      read_end, write_end = IO.pipe
+      write_end.write(File.read("spec/fixtures/seeds/test/posts.json"))
+      write_end.close
+      expected = JSON.load_file("spec/fixtures/seeds/test/posts.json")
+
+      result = described_class.new(read_end).parse
+
+      expect(result[:records].to_a).to eq(expected["records"])
+      read_end.close
+    end
+  end
+end

--- a/spec/lib/sprig/parser/yml_spec.rb
+++ b/spec/lib/sprig/parser/yml_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+
+RSpec.describe Sprig::Parser::Yml do
+  describe "#parse" do
+    it "matches YAML.load for a simple records-only file" do
+      file = File.open("spec/fixtures/seeds/test/posts.yml")
+      expected = YAML.load_file("spec/fixtures/seeds/test/posts.yml")
+
+      result = described_class.new(file).parse
+
+      expect(result[:records].to_a).to eq(expected["records"])
+      file.close
+    end
+
+    it "matches YAML.load when options (with an array-valued suboption) appears before records" do
+      file = File.open("spec/fixtures/seeds/test/posts_find_existing_by_multiple.yml")
+      expected = YAML.load_file("spec/fixtures/seeds/test/posts_find_existing_by_multiple.yml")
+
+      result = described_class.new(file).parse
+
+      expect(result[:options]).to eq(expected["options"])
+      expect(result[:records].to_a).to eq(expected["records"])
+      file.close
+    end
+
+    it "matches YAML.load for a record with a nested array attribute" do
+      file = File.open("spec/fixtures/seeds/test/posts_with_habtm.yml")
+      expected = YAML.load_file("spec/fixtures/seeds/test/posts_with_habtm.yml")
+
+      result = described_class.new(file).parse
+
+      expect(result[:records].to_a).to eq(expected["records"])
+      file.close
+    end
+
+    it "returns an empty hash for options when the file has none" do
+      file = File.open("spec/fixtures/seeds/test/posts.yml")
+
+      result = described_class.new(file).parse
+
+      expect(result[:options]).to eq({})
+      file.close
+    end
+
+    it "returns records as an Enumerator, not a realized Array" do
+      file = File.open("spec/fixtures/seeds/test/posts.yml")
+
+      result = described_class.new(file).parse
+
+      expect(result[:records]).to be_an(Enumerator)
+      file.close
+    end
+
+    it "falls back to buffering the whole file when data_io is not rewindable (e.g. a pipe)" do
+      read_end, write_end = IO.pipe
+      write_end.write(File.read("spec/fixtures/seeds/test/posts.yml"))
+      write_end.close
+      expected = YAML.load_file("spec/fixtures/seeds/test/posts.yml")
+
+      result = described_class.new(read_end).parse
+
+      expect(result[:records].to_a).to eq(expected["records"])
+      read_end.close
+    end
+  end
+end

--- a/spec/lib/sprig/source_spec.rb
+++ b/spec/lib/sprig/source_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe Sprig::Source do
       source = File.open("spec/fixtures/seeds/test/posts.yml")
       subject = Sprig::Source.new("posts", source: source, parser: Sprig::Parser::Yml)
 
-      expect(subject.records).to be_an(Array)
+      expect(subject.records).to be_an(Enumerable)
       expect(subject.records.first["title"]).to eq("Yaml title")
     end
 
-    it "returns an empty array when the parsed data has no records" do
+    it "returns an empty enumerable when the parsed data has no records" do
       source = StringIO.new("options:\n  delete_existing_by: title\n")
       subject = Sprig::Source.new("posts", source: source, parser: Sprig::Parser::Yml)
 
-      expect(subject.records).to eq([])
+      expect(subject.records.to_a).to eq([])
     end
   end
 
@@ -35,10 +35,44 @@ RSpec.describe Sprig::Source do
     end
   end
 
+  describe "source IO lifecycle" do
+    it "does not close the source until records is actually iterated" do
+      source = File.open("spec/fixtures/seeds/test/posts.yml")
+      subject = Sprig::Source.new("posts", source: source, parser: Sprig::Parser::Yml)
+
+      records = subject.records
+      expect(source).not_to be_closed
+
+      records.to_a
+      expect(source).to be_closed
+    end
+
+    it "closes the source if parsing itself raises" do
+      source = File.open("spec/fixtures/seeds/test/posts.yml")
+      allow(Sprig::Parser::Yml).to receive(:new).and_raise(RuntimeError, "boom")
+      subject = Sprig::Source.new("posts", source: source, parser: Sprig::Parser::Yml)
+
+      expect {
+        subject.options
+      }.to raise_error(RuntimeError, "boom")
+      expect(source).to be_closed
+    end
+
+    it "closes the source even if the consumer raises mid-iteration" do
+      source = File.open("spec/fixtures/seeds/test/posts_with_habtm.yml")
+      subject = Sprig::Source.new("posts", source: source, parser: Sprig::Parser::Yml)
+
+      expect {
+        subject.records.each { |_row| raise "boom" }
+      }.to raise_error("boom")
+      expect(source).to be_closed
+    end
+  end
+
   describe "with a custom source" do
     it "raises an ArgumentError if the source does not act like an IO" do
       expect {
-        Sprig::Source.new("posts", source: "not an io").records
+        Sprig::Source.new("posts", source: "not an io").records.to_a
       }.to raise_error(ArgumentError, "Data sources must act like an IO.")
     end
 
@@ -47,7 +81,7 @@ RSpec.describe Sprig::Source do
       source = StringIO.new("records: []")
 
       expect {
-        Sprig::Source.new("posts", source: source, parser: not_a_parser).records
+        Sprig::Source.new("posts", source: source, parser: not_a_parser).records.to_a
       }.to raise_error(ArgumentError, "Parsers must define #parse.")
     end
   end

--- a/sprig.gemspec
+++ b/sprig.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "csv", "~> 3.3"
+  s.add_dependency "oj", "~> 3.16"
 
   s.add_development_dependency "appraisal"
   s.add_development_dependency "rails", ">= 7.2", "< 9.0"


### PR DESCRIPTION
### Ticket

#75 

Resolve Sprig's excessive memory use when loading data.

Changes in this PR:
- Stream files directly from disk (rather than reading entirely in to memory at outset)

NOTE: This is Part 6 of 7 Parts.  See the [benchmark/README.md](https://github.com/vigetlabs/sprig/blob/ms/75-resolve-memory-version-3-part-7/benchmark/README.md) file for the complete explanation (it is unchanged across all stacked branches).

NOTE: Most of the content was authored by Claude Sonnet 5 under human supervision. Purely human-authored edits have their own commit.