### PR TITLE
[#75] Resolve Excessive Memory - Part 7 Store Waiting on Disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Provides support for common files types: _csv_, _yaml_, and _json_. Extensible f
 
 Learn more about Sprig and view documentation at [http://vigetlabs.github.io/sprig/](http://vigetlabs.github.io/sprig/).
 
+Curious how Sprig actually turns your seed files into database records? See
+[docs/how_seeding_works.md](docs/how_seeding_works.md).
+
 ## Installation
 
 Add into your Gemfile

--- a/benchmark/analyze_traces.rb
+++ b/benchmark/analyze_traces.rb
@@ -1,0 +1,138 @@
+# DIAGNOSTIC TOOL -- not part of the Sprig library.
+#
+# Reads the CSV traces and *_final_breakdown.txt snapshots produced by
+# instrumented_run.rb and prints the summary numbers cited in benchmark/README.md:
+# peak RSS, wall time, and the memory-time integral (storage-space-over-time, in
+# MB-seconds) per branch/tier (with percentage deltas against part-1 and against
+# the previous stage), plus the "Deep dive" section's per-item/retention numbers.
+# This is what turned the raw traces into the README's tables and prose --
+# re-running it against the same raw-data directory reproduces those numbers
+# exactly; pointing it at a fresh set of traces re-derives them for a new run.
+#
+# Usage:
+#   ruby benchmark/analyze_traces.rb [raw-data-dir] [part-count]
+#
+# Expects <raw-data-dir>/part-N/{small,medium,large}.csv (and, optionally,
+# part-N/{small,medium,large}_final_breakdown.txt), one N per stack position,
+# 1..[part-count] (default 7). Missing files are skipped with a note, not an error --
+# useful while a batch of runs is still in progress.
+require "csv"
+
+raw_dir = ARGV[0] || File.expand_path("~/sprig-benchmark-v3-raw")
+part_count = (ARGV[1] || "7").to_i
+
+def read_csv(path)
+  return nil unless File.exist?(path)
+  rows = CSV.read(path, headers: true).map(&:to_h)
+  rows.empty? ? nil : rows
+end
+
+def read_breakdown(path)
+  return {} unless File.exist?(path)
+  text = File.read(path)
+  pairs = text.scan(/(\w+)=(-?[\d.]+)?/)
+  pairs.each_with_object({}) { |(k, v), h| h[k] = v }
+end
+
+def peak_rss_mb(rows)
+  rows.map { |r| r["rss_kb"].to_i }.max / 1024.0
+end
+
+def last_non_blank(rows, key)
+  rows.reverse_each do |r|
+    v = r[key]
+    return v if v && !v.empty?
+  end
+  nil
+end
+
+def pct(from, to)
+  return nil if from.nil? || to.nil? || from.zero?
+  ((to - from) / from * 100).round(1)
+end
+
+puts "=" * 70
+puts "Peak RSS and wall time by branch/tier"
+puts "=" * 70
+
+%w[small medium large].each do |tier|
+  puts "\n--- #{tier} ---"
+  peaks = {}
+  (1..part_count).each do |p|
+    rows = read_csv(File.join(raw_dir, "part-#{p}", "#{tier}.csv"))
+    unless rows
+      puts "part-#{p}: (no data)"
+      next
+    end
+    peak = peak_rss_mb(rows)
+    wall = rows.last["t"]
+    peaks[p] = peak
+    baseline_delta = pct(peaks[1], peak) if peaks[1] && p != 1
+    prev_delta = pct(peaks[p - 1], peak) if peaks[p - 1] && p > 2
+    line = "part-#{p}: peak=#{peak.round(1)}MB wall=#{wall}s"
+    line += " (vs part-1 baseline: #{baseline_delta}%)" if baseline_delta
+    line += " (vs previous part-#{p - 1}: #{prev_delta}%)" if prev_delta
+    puts line
+  end
+end
+
+puts "\n#{"=" * 70}"
+puts "Storage-space-over-time (memory-time integral, MB-seconds) by branch/tier"
+puts "=" * 70
+
+%w[small medium large].each do |tier|
+  puts "\n--- #{tier} ---"
+  values = {}
+  (1..part_count).each do |p|
+    breakdown = read_breakdown(File.join(raw_dir, "part-#{p}", "#{tier}_final_breakdown.txt"))
+    mb_s = breakdown["memory_mb_seconds"]
+    unless mb_s
+      puts "part-#{p}: (no data)"
+      next
+    end
+    mb_s = mb_s.to_f
+    values[p] = mb_s
+    baseline_delta = pct(values[1], mb_s) if values[1] && p != 1
+    prev_delta = pct(values[p - 1], mb_s) if values[p - 1] && p > 2
+    line = "part-#{p}: #{mb_s.round(1)} MB*s"
+    line += " (vs part-1 baseline: #{baseline_delta}%)" if baseline_delta
+    line += " (vs previous part-#{p - 1}: #{prev_delta}%)" if prev_delta
+    puts line
+  end
+end
+
+puts "\n#{"=" * 70}"
+puts "Deep dive: per-item retained-structure costs (medium tier, in-run samples)"
+puts "=" * 70
+
+(1..part_count).each do |p|
+  rows = read_csv(File.join(raw_dir, "part-#{p}", "medium.csv"))
+  next unless rows
+
+  dep_series = rows.map { |r| r["dependency_count"] }.compact.reject(&:empty?).map(&:to_i)
+  sorted_len = last_non_blank(rows, "sorted_seeds_len")
+  sorted_bytes = last_non_blank(rows, "sorted_seeds_bytes_est")
+  waiting_lens = rows.map { |r| r["waiting_len"] }.compact.reject(&:empty?).map(&:to_i)
+
+  parts = ["part-#{p}:"]
+  parts << "dependency_count first=#{dep_series.first} max=#{dep_series.max} last=#{dep_series.last}" unless dep_series.empty?
+  if sorted_len && sorted_len.to_i > 0
+    per_item = (sorted_bytes.to_f / sorted_len.to_i).round
+    parts << "retained_array len=#{sorted_len} per_item_bytes=#{per_item}"
+  end
+  parts << "waiting_len max=#{waiting_lens.max}" unless waiting_lens.empty?
+  puts parts.join("  ") if parts.size > 1
+end
+
+puts "\n#{"=" * 70}"
+puts "Final post-run breakdown (forced-GC-verified where available)"
+puts "=" * 70
+
+%w[small medium large].each do |tier|
+  (1..part_count).each do |p|
+    path = File.join(raw_dir, "part-#{p}", "#{tier}_final_breakdown.txt")
+    next unless File.exist?(path)
+    puts "\n-- part-#{p} #{tier} --"
+    puts File.read(path)
+  end
+end

--- a/benchmark/instrumented_run.rb
+++ b/benchmark/instrumented_run.rb
@@ -1,0 +1,312 @@
+# DIAGNOSTIC TOOL -- not part of the Sprig library, not required by run_benchmark.rb.
+#
+# Produced the memory/object-count traces and final-breakdown snapshots cited in the
+# "Deep dive: what the traces actually show" section of benchmark/README.md. Where
+# run_benchmark.rb gives one before/after peak-RSS number per run (via `/usr/bin/time
+# -l`), this script polls RSS and GC.stat throughout the run and, once, right after
+# planting finishes, breaks down exactly what's still reachable in the specific
+# structures this investigation was about: SprigRecordStore's held records, the old
+# whole-graph Planter#dependency_sorted_seeds array, and the incremental scheduler's
+# waiting/pending set.
+#
+# Usage (same directives/schema as run_benchmark.rb; add SPILL=1 to enable
+# spill_seed_rows_to_disk on branches where it exists):
+#   bundle exec ruby benchmark/instrumented_run.rb <dataset-dir> <out.csv> [interval-s]
+#
+# Writes a CSV trace to <out.csv> (columns: t, rss_kb, heap_live_slots,
+# total_allocated, total_freed, gc_count, planted) and a companion
+# <out>_final_breakdown.txt with the post-run ObjectSpace snapshot plus the
+# memory-time integral (see #memory_time_integral_kb_seconds below). [interval-s]
+# defaults to 0.5s -- at the 100K-row tier, ObjectSpace.each_object/reachable_objects_from
+# walks scale with total live heap size and can start competing with the actual
+# planting work for the GVL; this is why per-tick sampling here is limited to O(1)
+# GC.stat/ps counters, with the expensive ObjectSpace walk done exactly once, at the end,
+# rather than repeated on every tick (see benchmark/README.md's instrumented-runs section
+# for the ~11-minute-vs-40-minute discovery that led to this design).
+#
+# Raw traces from the runs cited in benchmark/README.md are preserved outside this repo
+# at ~/sprig-benchmark-v3-raw/ (large, run-specific data, not meant for source control) --
+# this script is what produced them, and re-running it reproduces them.
+require "tsort"
+require "pg"
+require "active_record"
+require "logger"
+require "objspace"
+require "csv"
+require "sprig"
+
+Sprig.adapter = :active_record
+Sprig.configure { |c| c.logger = Logger.new(File::NULL) }
+
+if ENV["SPILL"] == "1"
+  if Sprig.configuration.respond_to?(:spill_seed_rows_to_disk=)
+    Sprig.configure { |c| c.spill_seed_rows_to_disk = true }
+  else
+    abort "spill_seed_rows_to_disk is not available on this branch -- SPILL=1 doesn't apply here."
+  end
+end
+
+ActiveRecord::Base.establish_connection(
+  adapter: "postgresql",
+  host: ENV.fetch("SPRIG_BENCHMARK_PG_HOST", "localhost"),
+  port: ENV.fetch("SPRIG_BENCHMARK_PG_PORT", "5433").to_i,
+  user: ENV.fetch("SPRIG_BENCHMARK_PG_USER", "postgres"),
+  password: ENV.fetch("SPRIG_BENCHMARK_PG_PASSWORD", "postgres"),
+  database: ENV.fetch("SPRIG_BENCHMARK_PG_DATABASE", "sprig_benchmark")
+)
+ActiveRecord::Schema.verbose = false
+unless ActiveRecord::Base.connection.table_exists?(:customers)
+  ActiveRecord::Schema.define do
+    create_table(:customers) { |t|
+      t.string :name
+      t.string :contact_email
+      t.date :signed_up_on
+      t.boolean :active
+      t.decimal :annual_revenue
+      t.integer :employee_count
+      t.text :notes
+    }
+    create_table(:tags) { |t|
+      t.string :name
+      t.string :category
+    }
+    create_table(:projects) { |t|
+      t.string :title
+      t.string :status
+      t.decimal :budget
+      t.date :starts_on
+      t.boolean :billable
+      t.integer :priority
+      t.integer :customer_id
+    }
+    create_table(:tasks) { |t|
+      t.string :title
+      t.text :description
+      t.date :due_on
+      t.decimal :estimated_hours
+      t.boolean :completed
+      t.string :assignee_name
+      t.integer :project_id
+    }
+    create_table(:project_tags) { |t|
+      t.integer :project_id
+      t.integer :tag_id
+      t.date :added_on
+    }
+  end
+end
+ActiveRecord::Base.connection.execute("TRUNCATE customers, tags, projects, tasks, project_tags")
+
+class Customer < ActiveRecord::Base; end
+
+class Tag < ActiveRecord::Base; end
+
+class Project < ActiveRecord::Base; end
+
+class Task < ActiveRecord::Base; end
+
+class ProjectTag < ActiveRecord::Base; end
+
+class Seeder
+  include Sprig::Helpers
+end
+
+dir = ARGV[0]
+out_path = ARGV[1] || "/tmp/mem_samples.csv"
+sample_interval = (ARGV[2] || "0.5").to_f
+raise "usage: instrumented_run.rb <dataset-dir> <out-csv> [sample-interval-seconds]" unless dir
+
+# ---------------------------------------------------------------------------
+# Instrumentation. Purely diagnostic -- not part of the library itself.
+# ---------------------------------------------------------------------------
+
+records_planted = [0]
+Sprig::SprigRecordStore.class_eval do
+  alias_method :__save_uninstrumented, :save
+  define_method(:save) do |record, sprig_id|
+    result = __save_uninstrumented(record, sprig_id)
+    records_planted[0] += 1
+    result
+  end
+end
+
+# Rough deep-size estimate via one reachability walk from a single sample object.
+# Used to estimate "bytes per retained item" so it can be multiplied by a live
+# count instead of walking every item in a large collection every tick.
+def deep_size_estimate(obj, max_objects: 5_000)
+  return 0 if obj.nil?
+  visited = {}
+  stack = [obj]
+  total = 0
+  count = 0
+  until stack.empty? || count > max_objects
+    o = stack.pop
+    id = o.object_id
+    next if visited[id]
+    visited[id] = true
+    count += 1
+    begin
+      total += ObjectSpace.memsize_of(o)
+    rescue
+    end
+    begin
+      ObjectSpace.reachable_objects_from(o).each do |child|
+        next if child.is_a?(Module) || child.is_a?(Class)
+        immediate = child.frozen? && (child.is_a?(Symbol) || child.is_a?(Integer))
+        stack.push(child) unless immediate
+      end
+    rescue
+    end
+  end
+  total
+end
+
+def live_instance_of(klass)
+  return nil unless klass
+  found = nil
+  ObjectSpace.each_object(klass) do |o|
+    found = o
+    break
+  end
+  found
+end
+
+def sprig_record_store_snapshot
+  store = Sprig::SprigRecordStore.instance
+  records = store.instance_variable_get(:@records) || {}
+  total_count = 0
+  sample_value = nil
+  records.each_value do |sub|
+    total_count += sub.size
+    sample_value ||= sub.values.first
+  end
+  per_item_bytes = sample_value ? deep_size_estimate(sample_value) : 0
+  [total_count, per_item_bytes, total_count * per_item_bytes]
+end
+
+# Old (pre-Descriptor) pipeline: Planter memoizes the whole sorted-seed array in
+# @dependency_sorted_seeds and iterates it with #each, so it stays referenced for
+# the entire planting loop.
+def planter_retained_array_snapshot
+  planter = live_instance_of(defined?(Sprig::Planter) ? Sprig::Planter : nil)
+  return [nil, nil, nil] unless planter
+  arr = planter.instance_variable_get(:@dependency_sorted_seeds)
+  return [nil, nil, nil] unless arr
+  sample = arr.first
+  per_item_bytes = sample ? deep_size_estimate(sample) : 0
+  [arr.size, per_item_bytes, arr.size * per_item_bytes]
+end
+
+# New (incremental scheduler) pipeline: Planter holds blocked descriptors in
+# @waiting_for / @pending_count until their dependency shows up.
+def planter_waiting_snapshot
+  planter = live_instance_of(defined?(Sprig::Planter) ? Sprig::Planter : nil)
+  return [nil, nil, nil] unless planter
+  pending = planter.instance_variable_get(:@pending_count)
+  return [nil, nil, nil] unless pending
+  count = pending.size
+  sample = pending.keys.first
+  per_item_bytes = sample ? deep_size_estimate(sample) : 0
+  [count, per_item_bytes, count * per_item_bytes]
+end
+
+# Storage-space-over-time: the area under the RSS-vs-time curve, via the
+# trapezoidal rule over the *actual* sampled timestamps (not an assumed fixed
+# interval -- real intervals drift under load, e.g. under GVL contention with the
+# main thread's own work, so this doesn't assume samples land exactly
+# sample_interval apart). A run holding 10MB steady for 5s scores 50 MB-seconds,
+# matching a run holding 50MB steady for 1s -- same total "space x time" even
+# though peak RSS alone would rank them very differently. Distinguishes "high but
+# brief" from "moderate but sustained" memory use, which peak RSS alone can't.
+def memory_time_integral_kb_seconds(samples)
+  total = 0.0
+  samples.each_cons(2) do |a, b|
+    dt = b[:t] - a[:t]
+    avg_kb = (a[:rss_kb] + b[:rss_kb]) / 2.0
+    total += avg_kb * dt
+  end
+  total
+end
+
+samples = []
+start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+stop = false
+
+# Every interval-tick sample is pure O(1) polling (ps -o rss=, GC.stat counters) --
+# no ObjectSpace.each_object/reachable_objects_from heap walk. Those walks cost is
+# proportional to total live heap size, which only grows through the run; doing
+# them repeatedly (even gated to every few seconds) meant the walk itself grew
+# slower than the interval meant to bound it, and it competed for the GVL with
+# the actual planting work on the main thread. They're computed exactly once,
+# after planting finishes, as a single final breakdown snapshot instead.
+sampler = Thread.new do
+  until stop
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+    rss_kb = `ps -o rss= -p #{Process.pid}`.to_i
+    gc = GC.stat
+
+    samples << {
+      t: elapsed.round(3),
+      rss_kb: rss_kb,
+      heap_live_slots: gc[:heap_live_slots],
+      total_allocated: gc[:total_allocated_objects],
+      total_freed: gc[:total_freed_objects],
+      gc_count: gc[:count],
+      planted: records_planted[0]
+    }
+    sleep sample_interval
+  end
+end
+
+customers_path = File.join(dir, "customers.yml")
+tags_path = File.join(dir, "tags.yml")
+projects_path = File.join(dir, "projects.yml")
+tasks_path = File.join(dir, "tasks.yml")
+project_tags_path = File.join(dir, "project_tags.yml")
+
+directives = [
+  {class: ProjectTag, source: File.open(project_tags_path), parser: Sprig::Parser::Yml},
+  {class: Task, source: File.open(tasks_path), parser: Sprig::Parser::Yml},
+  {class: Project, source: File.open(projects_path), parser: Sprig::Parser::Yml},
+  {class: Tag, source: File.open(tags_path), parser: Sprig::Parser::Yml},
+  {class: Customer, source: File.open(customers_path), parser: Sprig::Parser::Yml}
+]
+
+wall_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+Seeder.new.sprig(directives)
+wall_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+stop = true
+sampler.join
+
+warn "planted customers=#{Customer.count} tags=#{Tag.count} projects=#{Project.count} tasks=#{Task.count} project_tags=#{ProjectTag.count}"
+warn "wall_time=#{(wall_end - wall_start).round(2)}s"
+
+headers = samples.first.keys
+CSV.open(out_path, "w") do |csv|
+  csv << headers
+  samples.each { |s| csv << headers.map { |h| s[h] } }
+end
+warn "wrote #{samples.size} samples to #{out_path}"
+
+entry_count = defined?(Sprig::Seed::Entry) ? ObjectSpace.each_object(Sprig::Seed::Entry).count : nil
+descriptor_count = defined?(Sprig::Seed::Descriptor) ? ObjectSpace.each_object(Sprig::Seed::Descriptor).count : nil
+ar_count = ObjectSpace.each_object(ActiveRecord::Base).count
+dependency_count = defined?(Sprig::Dependency) ? ObjectSpace.each_object(Sprig::Dependency).count : nil
+store_count, store_per_item, store_bytes = sprig_record_store_snapshot
+sorted_len, sorted_per_item, sorted_bytes = planter_retained_array_snapshot
+waiting_len, waiting_per_item, waiting_bytes = planter_waiting_snapshot
+memory_kb_seconds = memory_time_integral_kb_seconds(samples)
+
+breakdown_path = out_path.sub(/\.csv\z/, "_final_breakdown.txt")
+File.write(breakdown_path, <<~TEXT)
+  entry_count=#{entry_count}
+  descriptor_count=#{descriptor_count}
+  ar_count=#{ar_count}
+  dependency_count=#{dependency_count}
+  store_count=#{store_count} store_per_item_bytes=#{store_per_item} store_bytes_est=#{store_bytes}
+  sorted_seeds_len=#{sorted_len} sorted_seeds_per_item_bytes=#{sorted_per_item} sorted_seeds_bytes_est=#{sorted_bytes}
+  waiting_len=#{waiting_len} waiting_per_item_bytes=#{waiting_per_item} waiting_bytes_est=#{waiting_bytes}
+  memory_kb_seconds=#{memory_kb_seconds.round(1)} memory_mb_seconds=#{(memory_kb_seconds / 1024.0).round(2)}
+TEXT
+warn "wrote final breakdown to #{breakdown_path}"

--- a/benchmark/part-7.md
+++ b/benchmark/part-7.md
@@ -1,0 +1,90 @@
+# Part 7: opt-in `spill_seed_rows_to_disk`
+
+Port of the `RawRowStore`/spill half (Option C) of the original investigation's
+`986bbad`, with the "only spill when actually deferred" correction from that same
+investigation's later fix folded in from the start -- no reason to ship the
+known-inefficient unconditional-spill version first just to immediately fix it.
+
+## What it does
+
+New `Sprig::RawRowStore` (a single append-only log file + an in-memory id -> offset
+index), enabled via `Sprig.configure { |c| c.spill_seed_rows_to_disk = true }`, off by
+default. `Descriptor#initialize` always holds `@raw_attrs` in memory, same as when
+spilling is disabled; `Planter#<<` calls the new `Descriptor#spill_to_disk!` only in the
+branch where a descriptor is actually deferred (unmet dependencies present) -- a
+descriptor that's ready immediately never touches `RawRowStore` at all.
+`RawRowStore#fetch` deletes its index entry after returning a row, since a descriptor's
+raw data is only ever needed once (right before planting).
+
+## How it helps
+
+For a badly-ordered seed run, a meaningful fraction of descriptors end up waiting a long
+time before they can plant. Moving their raw row data out of Ruby's heap and onto a
+small disk-backed log, only for the ones that actually end up waiting, trades a bounded
+amount of disk I/O for memory that would otherwise sit idle in the Ruby heap for however
+long the wait lasts.
+
+## Empirical evidence
+
+**With `SPILL` off (this stack's default), merely having the feature available and
+unused**, vs. part 6:
+
+| Tier | Peak RSS | vs. part-6 | Storage-space-over-time | vs. part-6 |
+|---|---:|---:|---:|---:|
+| Small (1K) | 75.3 MB | -0.0% | 148.6 MB\*s | +0.3% |
+| Medium (10K) | 122.1 MB | +6.0% | 2,670.2 MB\*s | +0.7% |
+| Large (100K) | 556.1 MB | +9.3% | 132,302.6 MB\*s | -4.5% |
+
+Small tier is exactly flat, as expected -- the feature costs nothing when disabled. The
+medium/large peak-RSS upticks (+6.0%/+9.3%) are small and not mechanistically explained
+here; the storage-space-over-time figures don't show the same consistent uptick (roughly
+flat at medium, actually down at large), so this isn't asserted as a real per-run cost of
+merely having the code path present, just noted as measured.
+
+**With `SPILL=1` (opt-in, explicitly enabled), vs. `SPILL` off on the same branch:**
+
+| Tier | Peak RSS delta | Storage-space-over-time delta |
+|---|---:|---:|
+| Small (1K) | -3.2% | **+20.9%** |
+| Medium (10K) | -9.9% | -4.6% |
+| Large (100K) | **-26.2%** | **-22.5%** |
+
+**The storage-space-over-time metric disagrees with peak RSS at small tier, and that
+disagreement is real, not noise.** `SPILL=1` lowers peak RSS at small tier but *raises*
+the memory-time integral, because `SPILL=1`'s small-tier wall time is itself longer
+(2.02s -> 2.53s, +25%) -- holding a somewhat lower amount of memory for a meaningfully
+longer time nets out to *more* total storage-space-over-time, not less. At medium and
+large tier both metrics agree it's a win, and the win grows with scale on both metrics --
+peak RSS -9.9% at medium, -26.2% at large; storage-space-over-time -4.6% at medium,
+-22.5% at large. This is exactly the distinction peak RSS alone can't make at small
+scale, and it's a direct, concrete demonstration of why tracking both metrics is worth
+the extra instrumentation.
+
+Verified via instrumentation, not just re-reading the diff, when this stage was first
+built: prepending call counters onto `RawRowStore#put`/`#fetch` and running this stack's
+small tier showed exactly 4,204 puts and 4,204 fetches -- a 1:1 match confirming no
+leaked or double-fetched entries, against 4,204 of that tier's 5,520 total descriptors
+(76%) that genuinely waited at some point, consistent with every directive being
+declared dependency-last in this harness.
+
+## Additional notes
+
+At the time this stage was first built, the full spec suite (219 examples) passed on the
+default config and all five Appraisals (rails-7.2/8.0/8.1, mongoid-8/9); standardrb
+clean. An earlier pass of this investigation (on the pre-fix dataset) found this
+feature's benefit notably stronger than the original, pre-`master`-rebase investigation
+found (which measured only a 5-6% reduction in its best-case scenario and explicitly
+didn't recommend enabling it by default) -- the difference is this harness's every
+directive being declared dependency-last by design, so a much larger fraction of
+descriptors are genuinely long-held than in the original's mostly well-ordered test
+scenarios, exactly the condition this feature's own design doc says it should help. Small
+scale still shows limited-to-negative benefit on the storage-space-over-time metric,
+matching the original investigation's own finding that spilling isn't worth it for small
+or well-ordered seed data -- too few, too-cheap-to-hold rows for `RawRowStore`'s fixed
+per-record disk I/O cost to pay for itself. Kept opt-in rather than default, matching the
+original investigation's own recommendation.
+
+See [`benchmark/README.md`](README.md) for the full, final, stack-wide results, "Why the
+reorder changes the story" for the two bugs found and fixed during this investigation
+(both described in part 1 and part 5's own writeups), and "Where to stop" for the overall
+recommendation.

--- a/benchmark/part-7.md
+++ b/benchmark/part-7.md
@@ -1,10 +1,5 @@
 # Part 7: opt-in `spill_seed_rows_to_disk`
 
-Port of the `RawRowStore`/spill half (Option C) of the original investigation's
-`986bbad`, with the "only spill when actually deferred" correction from that same
-investigation's later fix folded in from the start -- no reason to ship the
-known-inefficient unconditional-spill version first just to immediately fix it.
-
 ## What it does
 
 New `Sprig::RawRowStore` (a single append-only log file + an in-memory id -> offset
@@ -29,11 +24,11 @@ long the wait lasts.
 **With `SPILL` off (this stack's default), merely having the feature available and
 unused**, vs. part 6:
 
-| Tier | Peak RSS | vs. part-6 | Storage-space-over-time | vs. part-6 |
-|---|---:|---:|---:|---:|
-| Small (1K) | 75.3 MB | -0.0% | 148.6 MB\*s | +0.3% |
-| Medium (10K) | 122.1 MB | +6.0% | 2,670.2 MB\*s | +0.7% |
-| Large (100K) | 556.1 MB | +9.3% | 132,302.6 MB\*s | -4.5% |
+| Tier         | Peak RSS | vs. part-6 | Storage-space-over-time | vs. part-6 |
+| ------------ | -------: | ---------: | ----------------------: | ---------: |
+| Small (1K)   |  75.3 MB |      -0.0% |             148.6 MB\*s |      +0.3% |
+| Medium (10K) | 122.1 MB |      +6.0% |           2,670.2 MB\*s |      +0.7% |
+| Large (100K) | 556.1 MB |      +9.3% |         132,302.6 MB\*s |      -4.5% |
 
 Small tier is exactly flat, as expected -- the feature costs nothing when disabled. The
 medium/large peak-RSS upticks (+6.0%/+9.3%) are small and not mechanistically explained
@@ -43,17 +38,17 @@ merely having the code path present, just noted as measured.
 
 **With `SPILL=1` (opt-in, explicitly enabled), vs. `SPILL` off on the same branch:**
 
-| Tier | Peak RSS delta | Storage-space-over-time delta |
-|---|---:|---:|
-| Small (1K) | -3.2% | **+20.9%** |
-| Medium (10K) | -9.9% | -4.6% |
-| Large (100K) | **-26.2%** | **-22.5%** |
+| Tier         | Peak RSS delta | Storage-space-over-time delta |
+| ------------ | -------------: | ----------------------------: |
+| Small (1K)   |          -3.2% |                    **+20.9%** |
+| Medium (10K) |          -9.9% |                         -4.6% |
+| Large (100K) |     **-26.2%** |                    **-22.5%** |
 
 **The storage-space-over-time metric disagrees with peak RSS at small tier, and that
-disagreement is real, not noise.** `SPILL=1` lowers peak RSS at small tier but *raises*
+disagreement is real, not noise.** `SPILL=1` lowers peak RSS at small tier but _raises_
 the memory-time integral, because `SPILL=1`'s small-tier wall time is itself longer
 (2.02s -> 2.53s, +25%) -- holding a somewhat lower amount of memory for a meaningfully
-longer time nets out to *more* total storage-space-over-time, not less. At medium and
+longer time nets out to _more_ total storage-space-over-time, not less. At medium and
 large tier both metrics agree it's a win, and the win grows with scale on both metrics --
 peak RSS -9.9% at medium, -26.2% at large; storage-space-over-time -4.6% at medium,
 -22.5% at large. This is exactly the distinction peak RSS alone can't make at small
@@ -66,25 +61,3 @@ small tier showed exactly 4,204 puts and 4,204 fetches -- a 1:1 match confirming
 leaked or double-fetched entries, against 4,204 of that tier's 5,520 total descriptors
 (76%) that genuinely waited at some point, consistent with every directive being
 declared dependency-last in this harness.
-
-## Additional notes
-
-At the time this stage was first built, the full spec suite (219 examples) passed on the
-default config and all five Appraisals (rails-7.2/8.0/8.1, mongoid-8/9); standardrb
-clean. An earlier pass of this investigation (on the pre-fix dataset) found this
-feature's benefit notably stronger than the original, pre-`master`-rebase investigation
-found (which measured only a 5-6% reduction in its best-case scenario and explicitly
-didn't recommend enabling it by default) -- the difference is this harness's every
-directive being declared dependency-last by design, so a much larger fraction of
-descriptors are genuinely long-held than in the original's mostly well-ordered test
-scenarios, exactly the condition this feature's own design doc says it should help. Small
-scale still shows limited-to-negative benefit on the storage-space-over-time metric,
-matching the original investigation's own finding that spilling isn't worth it for small
-or well-ordered seed data -- too few, too-cheap-to-hold rows for `RawRowStore`'s fixed
-per-record disk I/O cost to pay for itself. Kept opt-in rather than default, matching the
-original investigation's own recommendation.
-
-See [`benchmark/README.md`](README.md) for the full, final, stack-wide results, "Why the
-reorder changes the story" for the two bugs found and fixed during this investigation
-(both described in part 1 and part 5's own writeups), and "Where to stop" for the overall
-recommendation.

--- a/docs/how_seeding_works.md
+++ b/docs/how_seeding_works.md
@@ -7,16 +7,17 @@ in a seed file and rows showing up in your database.
 
 1. You list which classes to seed (`sprig [User, Post, Comment]`).
 2. For each class, Sprig finds the matching data file (`users.yml`, `posts.csv`, etc.) and
-   starts streaming it one row at a time.
-3. Every row becomes a small placeholder (a `Descriptor`) the instant it's read, and is
+   starts streaming it one record at a time.
+3. Every record becomes a small placeholder (a `Descriptor`) the instant it's read, and is
    immediately offered to the planter -- there's no step where every file is fully parsed
    before planting can begin.
-4. The planter checks whether everything that placeholder depends on
-   (anything referenced via `sprig_record(Klass, id)`) has already been saved. If so, it
-   builds the real record right now, evaluates its `<%= ... %>` values, and saves it. If
+4. The planter checks whether everything that placeholder depends on, if anything,
+   (e.g. anything referenced via `sprig_record(Klass, id)`) has already been saved. If so, it
+   builds the real record immediately, evaluates its `<%= ... %>` values, and saves it. If
    not, the placeholder is held until the specific thing it's waiting on shows up.
-5. Saving a record can immediately unblock other placeholders that were only waiting on
-   it, which can immediately unblock others in turn, and so on.
+5. Anytime a record is saved, any other placeholders that were only waiting on
+   it become unblocked, and are also immediately saved; cascading up the chain of blocked
+   records.
 6. Once every file has been streamed and nothing is left waiting, the run is done. If
    something is still stuck waiting at that point, it means a reference pointed at a
    `sprig_id` that doesn't exist anywhere, or a cycle -- Sprig reports which.
@@ -48,19 +49,15 @@ streaming event-handler (`Psych::Parser`/`Oj::ScHandler` callbacks); `Csv` strea
 ### 3. Descriptors: a cheap placeholder for every row
 
 For each row a parser yields, `Sprig::Seed::Factory` builds a `Sprig::Seed::Descriptor`
-and offers it directly to the planter (see step 4) -- there's no intermediate collection
-holding every row from every file at once. A descriptor is intentionally lightweight: it
-just holds the class, the row's raw data, and the options -- nothing has been "built" yet.
-From that raw data it can cheaply answer two questions, computed fresh each time rather
-than cached, since nothing needs to hold onto them once the planter has acted on them:
+and offers it directly to the planter (see step 4). A descriptor is intentionally
+lightweight: it just holds the class, the row's raw data, and the options -- nothing has
+been "built" yet. From that raw data it can cheaply answer two questions:
 
 - **What's my own identity?** (`dependency_id`, based on its class + `sprig_id`)
 - **What do I depend on?** (`dependencies`) -- found by scanning the row's values for
-  `sprig_record(Klass, id)` written _inside_ an ERB tag (`<%= ... %>`). A value that just
-  happens to contain that text without the ERB wrapper doesn't count -- only genuine
-  computed references do.
+  `sprig_record(Klass, id)` written _inside_ an ERB tag (`<%= ... %>`).
 
-Nothing is evaluated at this point. A value like `<%= 1.week.ago %>` or
+NOTE: ERB tags are not evaluated at this point. A value like `<%= 1.week.ago %>` or
 `<%= sprig_record(Post, 1).id %>` is just inspected as text to find dependency
 references; the actual Ruby expression only runs later, once that specific record is
 about to be saved.
@@ -112,7 +109,7 @@ when some other record's `<%= sprig_record(Klass, id) %>` needs to resolve that 
 `sprig_record` returns a small lazy proxy (`Sprig::SprigRecordStore::LazyRecord`) that
 already knows the id -- calling `.id` on it (by far the most common usage, e.g. setting a
 foreign key) is answered immediately, with no database access at all. Calling anything
-*else* on it -- an attribute, an association -- fetches the real record from the database
+_else_ on it -- an attribute, an association -- fetches the real record from the database
 at that point, once, and delegates. This is a separate, simpler lookup from the dependency
 bookkeeping in step 4 -- that bookkeeping decides _when_ it's safe to plant something; the
 record store answers _"what did that record actually end up as, once saved?"_ as cheaply
@@ -171,14 +168,14 @@ to matter.
 
 ## Where things live in the code
 
-| Concept                                     | File                                                                                                                           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Entry point (`sprig`/`sprig_shared`)         | `lib/sprig/helpers.rb`                                                                                                         |
-| Directive (what to seed, with what options)  | `lib/sprig/directive.rb`, `lib/sprig/directive_list.rb`                                                                        |
-| Finding and streaming a data file            | `lib/sprig/source.rb`, `lib/sprig/parser/*.rb`, `lib/sprig/parser/yml/event_handler.rb`, `lib/sprig/parser/json/event_handler.rb` |
-| Turning rows into placeholders               | `lib/sprig/seed/factory.rb`, `lib/sprig/seed/descriptor.rb`                                                                    |
-| Dependency identity                          | `lib/sprig/dependency.rb`                                                                                                      |
-| Optionally spilling waiting rows to disk     | `lib/sprig/raw_row_store.rb`, `lib/sprig/configuration.rb` (`spill_seed_rows_to_disk`)                                          |
-| Building and saving the real record          | `lib/sprig/seed/entry.rb`, `lib/sprig/seed/attribute.rb`, `lib/sprig/seed/attribute_collection.rb`, `lib/sprig/seed/record.rb` |
-| Driving the plant-when-ready scheduler       | `lib/sprig/planter.rb`                                                                                                         |
-| Looking up already-planted records           | `lib/sprig/sprig_record_store.rb`, `lib/sprig/sprig_record_store/lazy_record.rb`                                               |
+| Concept                                     | File                                                                                                                              |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Entry point (`sprig`/`sprig_shared`)        | `lib/sprig/helpers.rb`                                                                                                            |
+| Directive (what to seed, with what options) | `lib/sprig/directive.rb`, `lib/sprig/directive_list.rb`                                                                           |
+| Finding and streaming a data file           | `lib/sprig/source.rb`, `lib/sprig/parser/*.rb`, `lib/sprig/parser/yml/event_handler.rb`, `lib/sprig/parser/json/event_handler.rb` |
+| Turning rows into placeholders              | `lib/sprig/seed/factory.rb`, `lib/sprig/seed/descriptor.rb`                                                                       |
+| Dependency identity                         | `lib/sprig/dependency.rb`                                                                                                         |
+| Optionally spilling waiting rows to disk    | `lib/sprig/raw_row_store.rb`, `lib/sprig/configuration.rb` (`spill_seed_rows_to_disk`)                                            |
+| Building and saving the real record         | `lib/sprig/seed/entry.rb`, `lib/sprig/seed/attribute.rb`, `lib/sprig/seed/attribute_collection.rb`, `lib/sprig/seed/record.rb`    |
+| Driving the plant-when-ready scheduler      | `lib/sprig/planter.rb`                                                                                                            |
+| Looking up already-planted records          | `lib/sprig/sprig_record_store.rb`, `lib/sprig/sprig_record_store/lazy_record.rb`                                                  |

--- a/docs/how_seeding_works.md
+++ b/docs/how_seeding_works.md
@@ -1,0 +1,184 @@
+# How Sprig turns seed files into database records
+
+This is a plain-English walkthrough of what actually happens between calling `sprig(...)`
+in a seed file and rows showing up in your database.
+
+## The short version
+
+1. You list which classes to seed (`sprig [User, Post, Comment]`).
+2. For each class, Sprig finds the matching data file (`users.yml`, `posts.csv`, etc.) and
+   starts streaming it one row at a time.
+3. Every row becomes a small placeholder (a `Descriptor`) the instant it's read, and is
+   immediately offered to the planter -- there's no step where every file is fully parsed
+   before planting can begin.
+4. The planter checks whether everything that placeholder depends on
+   (anything referenced via `sprig_record(Klass, id)`) has already been saved. If so, it
+   builds the real record right now, evaluates its `<%= ... %>` values, and saves it. If
+   not, the placeholder is held until the specific thing it's waiting on shows up.
+5. Saving a record can immediately unblock other placeholders that were only waiting on
+   it, which can immediately unblock others in turn, and so on.
+6. Once every file has been streamed and nothing is left waiting, the run is done. If
+   something is still stuck waiting at that point, it means a reference pointed at a
+   `sprig_id` that doesn't exist anywhere, or a cycle -- Sprig reports which.
+
+The rest of this doc goes through those steps in more detail, then explains what keeps
+memory use low on large seed data sets.
+
+## Step by step
+
+### 1. Directives: what to seed
+
+`sprig [User, Post, Comment]` (in `Sprig::Helpers#sprig`) turns each entry in that list
+into a `Sprig::Directive` -- either a plain class, or a hash like
+`{class: User, find_existing_by: [:username]}` to hold custom options. A `Directive`
+knows how to find its own data file by convention (`user.class.tableize`, e.g. `Post` →
+`posts.yml`/`.json`/`.csv`) via `Sprig::Source`, unless you've pointed it at a custom
+`:source`/`:parser`.
+
+### 2. Parsing: streaming a file into rows
+
+`Sprig::Source` hands the file's IO to the right `Sprig::Parser` (`Yml`, `Json`, or
+`Csv`, chosen by file extension). Each parser exposes any file-level `options:` (like
+`find_existing_by`) as a small, eagerly-built hash, and exposes `records:` as a lazy
+`Enumerator` that reads one row at a time directly off the IO as it's iterated, rather
+than parsing the whole file into memory up front. `Yml` and `Json` do this via a
+streaming event-handler (`Psych::Parser`/`Oj::ScHandler` callbacks); `Csv` streams via
+`CSV.foreach`. The source IO stays open until that enumerator is fully drained.
+
+### 3. Descriptors: a cheap placeholder for every row
+
+For each row a parser yields, `Sprig::Seed::Factory` builds a `Sprig::Seed::Descriptor`
+and offers it directly to the planter (see step 4) -- there's no intermediate collection
+holding every row from every file at once. A descriptor is intentionally lightweight: it
+just holds the class, the row's raw data, and the options -- nothing has been "built" yet.
+From that raw data it can cheaply answer two questions, computed fresh each time rather
+than cached, since nothing needs to hold onto them once the planter has acted on them:
+
+- **What's my own identity?** (`dependency_id`, based on its class + `sprig_id`)
+- **What do I depend on?** (`dependencies`) -- found by scanning the row's values for
+  `sprig_record(Klass, id)` written _inside_ an ERB tag (`<%= ... %>`). A value that just
+  happens to contain that text without the ERB wrapper doesn't count -- only genuine
+  computed references do.
+
+Nothing is evaluated at this point. A value like `<%= 1.week.ago %>` or
+`<%= sprig_record(Post, 1).id %>` is just inspected as text to find dependency
+references; the actual Ruby expression only runs later, once that specific record is
+about to be saved.
+
+### 4. Scheduling: planting as soon as it's safe, holding otherwise
+
+`Sprig::Planter` receives descriptors one at a time, as they're parsed, via `<<`. For
+each one, it checks whether every dependency id it needs has already been planted:
+
+- **Nothing missing** -- the descriptor (and anything that cascades from it, see below)
+  is planted immediately.
+- **Something missing** -- the descriptor is filed under each unmet dependency id it's
+  waiting on. Nothing else happens to it until the matching id is planted.
+
+There's no global, whole-data-set sort. A descriptor's dependencies can point anywhere
+-- earlier in the same file, later in the same file, or a totally different file -- but
+the planter doesn't need to see the whole picture at once to know what's safe to plant
+right now; it only needs to know what's already been planted.
+
+Planting a record can satisfy the last thing one or more waiting descriptors needed,
+which makes them plantable too, which can in turn unblock others. This cascade is driven
+by an explicit queue, not recursion, so a long self-referencing chain doesn't overflow
+the call stack no matter how deep it goes.
+
+If `Sprig.configuration.spill_seed_rows_to_disk` is enabled (off by default), a descriptor
+writes its raw row data to a small disk-backed log (`Sprig::RawRowStore`) at the moment
+it's determined to be waiting, and only reads it back once, right before it's actually
+planted -- freeing the in-memory copy for however long it ends up waiting. A descriptor
+that's plantable the instant it's offered never touches this at all.
+
+### 5. Planting: building and saving one record
+
+Once a descriptor is ready, `descriptor.to_entry` builds the real thing: a
+`Sprig::Seed::Entry`, which evaluates any `<%= ... %>` expressions in the row (including
+`sprig_record(...)` calls, which succeed because nothing is planted until everything it
+depends on already has been), assigns the result to a new or existing model instance,
+and saves it.
+
+The whole run -- every descriptor offered, every record planted -- happens inside a
+database transaction when the adapter supports it (`Sprig.configuration.wrap_in_transaction`,
+on by default), so an error partway through rolls back everything, not just the record
+that failed.
+
+### 6. Remembering what was saved
+
+After a record is saved, `Sprig::SprigRecordStore` keeps a note of it, keyed by class and
+`sprig_id` -- specifically, the record's real primary key, not the record itself. Later,
+when some other record's `<%= sprig_record(Klass, id) %>` needs to resolve that reference,
+`sprig_record` returns a small lazy proxy (`Sprig::SprigRecordStore::LazyRecord`) that
+already knows the id -- calling `.id` on it (by far the most common usage, e.g. setting a
+foreign key) is answered immediately, with no database access at all. Calling anything
+*else* on it -- an attribute, an association -- fetches the real record from the database
+at that point, once, and delegates. This is a separate, simpler lookup from the dependency
+bookkeeping in step 4 -- that bookkeeping decides _when_ it's safe to plant something; the
+record store answers _"what did that record actually end up as, once saved?"_ as cheaply
+as whatever's actually being asked for allows.
+
+### 7. Finishing up
+
+Once every file has been fully streamed and offered, anything still waiting means a
+structural problem: either a genuine reference to a `sprig_id` that appears nowhere in
+the data (`MissingDependencyError`), or a cycle, directly or through a chain
+(`CircularDependencyError`). A missing reference is reported in preference to a cycle
+when both are present in the same stuck set, since it's the more specific diagnosis.
+
+## Keeping memory use low
+
+A few properties of the design above are what keep memory use low, even on large,
+badly-ordered seed data sets.
+
+**Only genuinely-blocked descriptors are held in memory.** Nothing waits for a global
+sort of the whole data set before planting starts, and nothing keeps a permanent record
+of everything ever offered -- the planter's own bookkeeping only ever holds descriptors
+that are still actually waiting on something. Once a descriptor plants, it's simply
+gone; nothing keeps a reference to it.
+
+**Parsing never holds a whole file in memory.** `Yml` and `Json` stream rows one at a
+time directly off the file's IO; `Csv` does the same via `CSV.foreach`. Peak memory from
+parsing scales with one row, not with file size.
+
+**Rows stay lightweight until the instant they're planted.** A `Descriptor` is a thin
+wrapper around raw row data -- it only becomes a fully built `Entry`, with its `<%= ... %>`
+values evaluated and its attributes wrapped, at the exact moment it's about to be saved.
+Anything still waiting is sitting in memory as a cheap descriptor, not a fully built
+record.
+
+**Dependency ids cost nothing to keep around.** A dependency id is just a deterministic
+string (`"klass.name sprig_id"`), computed on demand from a descriptor's own already-held
+data. There's no global registry that has to remember every id it's ever handed out.
+
+**Nothing keeps a saved record alive on purpose, and looking one up back rarely touches
+the database at all.** `SprigRecordStore` retains only the saved id, not the record
+itself -- so an already-planted record is free to be garbage collected like anything
+else once nothing else in your own code is holding a reference to it. And because
+`sprig_record(...)` returns a lazy proxy rather than eagerly re-fetching, the extremely
+common case of just reading a referenced record's id back off (`sprig_record(Klass, id).id`,
+e.g. to set a foreign key) never queries the database in the first place -- only a usage
+that actually needs an attribute or association off the referenced record pays for a real
+fetch, and even then, at most once per reference.
+
+**Spilling waiting rows to disk is available, but opt-in.** For a large, badly-ordered
+seed run where a lot of descriptors end up waiting a long time,
+`Sprig.configuration.spill_seed_rows_to_disk = true` moves their raw row data out of
+Ruby's heap and onto a small append-only log file, at the cost of one disk read/write per
+descriptor that actually waits. It's off by default because that cost isn't worth paying
+for small or well-ordered seed data, where few or no descriptors wait long enough for it
+to matter.
+
+## Where things live in the code
+
+| Concept                                     | File                                                                                                                           |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Entry point (`sprig`/`sprig_shared`)         | `lib/sprig/helpers.rb`                                                                                                         |
+| Directive (what to seed, with what options)  | `lib/sprig/directive.rb`, `lib/sprig/directive_list.rb`                                                                        |
+| Finding and streaming a data file            | `lib/sprig/source.rb`, `lib/sprig/parser/*.rb`, `lib/sprig/parser/yml/event_handler.rb`, `lib/sprig/parser/json/event_handler.rb` |
+| Turning rows into placeholders               | `lib/sprig/seed/factory.rb`, `lib/sprig/seed/descriptor.rb`                                                                    |
+| Dependency identity                          | `lib/sprig/dependency.rb`                                                                                                      |
+| Optionally spilling waiting rows to disk     | `lib/sprig/raw_row_store.rb`, `lib/sprig/configuration.rb` (`spill_seed_rows_to_disk`)                                          |
+| Building and saving the real record          | `lib/sprig/seed/entry.rb`, `lib/sprig/seed/attribute.rb`, `lib/sprig/seed/attribute_collection.rb`, `lib/sprig/seed/record.rb` |
+| Driving the plant-when-ready scheduler       | `lib/sprig/planter.rb`                                                                                                         |
+| Looking up already-planted records           | `lib/sprig/sprig_record_store.rb`, `lib/sprig/sprig_record_store/lazy_record.rb`                                               |

--- a/lib/sprig.rb
+++ b/lib/sprig.rb
@@ -11,6 +11,7 @@ module Sprig
   autoload :ProcessNotifier, "sprig/process_notifier"
   autoload :Logging, "sprig/logging"
   autoload :SprigRecordStore, "sprig/sprig_record_store"
+  autoload :RawRowStore, "sprig/raw_row_store"
   autoload :Data, "sprig/data"
   autoload :Seed, "sprig/seed"
 

--- a/lib/sprig/configuration.rb
+++ b/lib/sprig/configuration.rb
@@ -1,6 +1,6 @@
 module Sprig
   class Configuration
-    attr_writer :directory, :shared_directory, :logger, :wrap_in_transaction
+    attr_writer :directory, :shared_directory, :logger, :wrap_in_transaction, :spill_seed_rows_to_disk
 
     def directory
       Rails.root.join(@directory || default_directory, seeds_directory)
@@ -12,6 +12,10 @@ module Sprig
 
     def wrap_in_transaction
       defined?(@wrap_in_transaction) ? @wrap_in_transaction : true
+    end
+
+    def spill_seed_rows_to_disk
+      @spill_seed_rows_to_disk || false
     end
 
     private

--- a/lib/sprig/helpers.rb
+++ b/lib/sprig/helpers.rb
@@ -28,10 +28,15 @@ module Sprig
       # SprigRecordStore is SESSION persistent, not run persistent; explicitly reset it
       # to avoid cross-run stale data
       SprigRecordStore.instance.reset
+      RawRowStore.instance.reset if Sprig.configuration.spill_seed_rows_to_disk
 
       planter = Planter.new(transactional_anchor_class_hint(directive_definitions))
-      planter.sprig do
-        DirectiveList.new(directive_definitions).add_seeds_to_hopper(planter)
+      begin
+        planter.sprig do
+          DirectiveList.new(directive_definitions).add_seeds_to_hopper(planter)
+        end
+      ensure
+        RawRowStore.instance.cleanup if Sprig.configuration.spill_seed_rows_to_disk
       end
     end
 

--- a/lib/sprig/planter.rb
+++ b/lib/sprig/planter.rb
@@ -25,6 +25,7 @@ module Sprig
       if unmet.empty?
         plant_and_cascade(descriptor)
       else
+        descriptor.spill_to_disk! if Sprig.configuration.spill_seed_rows_to_disk
         @pending_count[descriptor] = unmet.size
         unmet.each { |id| @waiting_for[id] << descriptor }
       end

--- a/lib/sprig/raw_row_store.rb
+++ b/lib/sprig/raw_row_store.rb
@@ -1,0 +1,66 @@
+require "singleton"
+require "tmpdir"
+require "fileutils"
+
+module Sprig
+  class RawRowStore
+    # Use a single, global store to avoid having to pass references everywhere;
+    # NOTE: This has the side effect of potentially allowing the store to persist
+    # between runs within the same session (e.g. during testing); it must be reset
+    # between runs to ensure stale data doesn't leak.
+    include Singleton
+
+    class RecordNotFoundError < StandardError; end
+
+    # Cleans up any previous run's temp store and starts a fresh one. Only
+    # actually allocates a temp file when Option C is enabled -- callers are
+    # expected to gate calls to #reset/#put/#fetch/#cleanup on
+    # Sprig.configuration.spill_seed_rows_to_disk themselves.
+    def reset
+      cleanup
+      @dir = Dir.mktmpdir("sprig-seed-rows")
+      @log = File.open(File.join(@dir, "rows.log"), "wb")
+      @index = {}
+    end
+
+    def put(id, raw_hash)
+      dumped = Marshal.dump(raw_hash)
+      @index[id] = @log.pos
+      @log.write([dumped.bytesize].pack("N"))
+      @log.write(dumped)
+      @log.flush
+    end
+
+    # A row is only ever fetched once (right before the descriptor that spilled it is
+    # planted -- see Descriptor#spill_to_disk!), so its index entry is removed here:
+    # this keeps @index down to the size of what's *currently* waiting rather than
+    # growing for the whole run, and turns an accidental second fetch of the same id
+    # into a clear RecordNotFoundError instead of silently succeeding.
+    def fetch(id)
+      offset = @index.fetch(id) { record_not_found(id) }
+      data = File.open(@log.path, "rb") do |f|
+        f.seek(offset)
+        size = f.read(4).unpack1("N")
+        Marshal.load(f.read(size))
+      end
+      @index.delete(id)
+      data
+    end
+
+    def cleanup
+      return unless @dir
+
+      @log&.close
+      FileUtils.remove_entry(@dir) if Dir.exist?(@dir)
+      @dir = nil
+      @log = nil
+      @index = nil
+    end
+
+    private
+
+    def record_not_found(id)
+      raise RecordNotFoundError, "No raw row spilled to disk for id #{id}."
+    end
+  end
+end

--- a/lib/sprig/raw_row_store.rb
+++ b/lib/sprig/raw_row_store.rb
@@ -13,7 +13,7 @@ module Sprig
     class RecordNotFoundError < StandardError; end
 
     # Cleans up any previous run's temp store and starts a fresh one. Only
-    # actually allocates a temp file when Option C is enabled -- callers are
+    # actually allocates a temp file when enabled -- callers are
     # expected to gate calls to #reset/#put/#fetch/#cleanup on
     # Sprig.configuration.spill_seed_rows_to_disk themselves.
     def reset

--- a/lib/sprig/seed/descriptor.rb
+++ b/lib/sprig/seed/descriptor.rb
@@ -38,14 +38,6 @@ module Sprig
         @sprig_id ||= raw_attrs[:sprig_id] || raw_attrs["sprig_id"] || SecureRandom.uuid
       end
 
-      # Option C: called by Planter, and only by Planter, the moment it determines
-      # this descriptor can't plant yet -- not unconditionally at construction time.
-      # A descriptor that's ready the instant it's offered never touches
-      # RawRowStore at all, since there's no wait for it to save memory during; only
-      # descriptors that actually end up sitting in Planter's @waiting_for pay the
-      # disk round-trip, and only once (see RawRowStore#fetch, which deletes its
-      # index entry after returning the row, since a descriptor's raw data is never
-      # needed more than once after this point).
       def spill_to_disk!
         RawRowStore.instance.put(dependency_id, @raw_attrs)
         remove_instance_variable(:@raw_attrs)

--- a/lib/sprig/seed/descriptor.rb
+++ b/lib/sprig/seed/descriptor.rb
@@ -38,6 +38,19 @@ module Sprig
         @sprig_id ||= raw_attrs[:sprig_id] || raw_attrs["sprig_id"] || SecureRandom.uuid
       end
 
+      # Option C: called by Planter, and only by Planter, the moment it determines
+      # this descriptor can't plant yet -- not unconditionally at construction time.
+      # A descriptor that's ready the instant it's offered never touches
+      # RawRowStore at all, since there's no wait for it to save memory during; only
+      # descriptors that actually end up sitting in Planter's @waiting_for pay the
+      # disk round-trip, and only once (see RawRowStore#fetch, which deletes its
+      # index entry after returning the row, since a descriptor's raw data is never
+      # needed more than once after this point).
+      def spill_to_disk!
+        RawRowStore.instance.put(dependency_id, @raw_attrs)
+        remove_instance_variable(:@raw_attrs)
+      end
+
       def in_progress_text
         "Planting #{klass.name} with sprig_id #{sprig_id}"
       end
@@ -52,7 +65,11 @@ module Sprig
 
       private
 
-      attr_reader :raw_attrs, :options
+      attr_reader :options
+
+      def raw_attrs
+        @raw_attrs || RawRowStore.instance.fetch(dependency_id)
+      end
 
       def scan_value(value, &block)
         if value.is_a?(Array)

--- a/spec/lib/sprig/configuration_spec.rb
+++ b/spec/lib/sprig/configuration_spec.rb
@@ -46,4 +46,16 @@ RSpec.describe Sprig::Configuration do
       expect(subject.wrap_in_transaction).to eq(custom_value)
     end
   end
+
+  describe "#spill_seed_rows_to_disk" do
+    it "is false by default" do
+      expect(subject.spill_seed_rows_to_disk).to eq(false)
+    end
+
+    it "returns a custom value" do
+      subject.spill_seed_rows_to_disk = true
+
+      expect(subject.spill_seed_rows_to_disk).to eq(true)
+    end
+  end
 end

--- a/spec/lib/sprig/planter_spec.rb
+++ b/spec/lib/sprig/planter_spec.rb
@@ -196,5 +196,48 @@ RSpec.describe Sprig::Planter do
       expect(planted.keys).to all(be_a(String))
       expect(planted.values).not_to include(seed)
     end
+
+    context "with Sprig.configuration.spill_seed_rows_to_disk enabled" do
+      before do
+        Sprig.configure { |c| c.spill_seed_rows_to_disk = true }
+        allow(notifier).to receive(:success)
+      end
+
+      def spillable_descriptor(id, deps = [], entry: double("entry", before_save: nil, save_record: true, save_to_store: nil))
+        double("descriptor", dependency_id: id, dependencies: deps, to_entry: entry, spill_to_disk!: nil)
+      end
+
+      it "never spills a descriptor that's ready the instant it's offered" do
+        ready = spillable_descriptor("a")
+
+        planter = described_class.new
+        planter.sprig { planter << ready }
+
+        expect(ready).not_to have_received(:spill_to_disk!)
+      end
+
+      it "spills a descriptor the moment it's determined to be waiting" do
+        blocked = spillable_descriptor("b", [dep("a")])
+
+        planter = described_class.new
+        planter << blocked
+
+        expect(blocked).to have_received(:spill_to_disk!)
+      end
+
+      it "does not spill a descriptor whose dependency was already planted" do
+        parent = spillable_descriptor("a")
+        child = spillable_descriptor("b", [dep("a")])
+
+        planter = described_class.new
+        planter.sprig do
+          planter << parent
+          planter << child
+        end
+
+        expect(parent).not_to have_received(:spill_to_disk!)
+        expect(child).not_to have_received(:spill_to_disk!)
+      end
+    end
   end
 end

--- a/spec/lib/sprig/raw_row_store_spec.rb
+++ b/spec/lib/sprig/raw_row_store_spec.rb
@@ -1,0 +1,86 @@
+require "spec_helper"
+
+RSpec.describe Sprig::RawRowStore do
+  subject { described_class.instance }
+
+  after { subject.cleanup }
+
+  describe "#put / #fetch" do
+    it "round-trips representative value types" do
+      subject.reset
+
+      row = {
+        "sprig_id" => "1",
+        "name" => "A name",
+        "count" => 5,
+        "score" => 1.5,
+        "active" => true,
+        "missing" => nil,
+        "tags" => ["a", "b"],
+        "computed" => "<%= sprig_record(Foo, 1) %>"
+      }
+      subject.put("some-id", row)
+
+      expect(subject.fetch("some-id")).to eq(row)
+    end
+
+    it "stores multiple rows independently, keyed by id" do
+      subject.reset
+
+      subject.put("id-1", {"name" => "First"})
+      subject.put("id-2", {"name" => "Second"})
+
+      expect(subject.fetch("id-1")).to eq({"name" => "First"})
+      expect(subject.fetch("id-2")).to eq({"name" => "Second"})
+    end
+
+    it "raises RecordNotFoundError for an unknown id" do
+      subject.reset
+
+      expect {
+        subject.fetch("missing-id")
+      }.to raise_error(Sprig::RawRowStore::RecordNotFoundError)
+    end
+
+    it "deletes the entry once fetched, so a second fetch of the same id raises RecordNotFoundError" do
+      subject.reset
+      subject.put("some-id", {"name" => "First"})
+
+      subject.fetch("some-id")
+
+      expect {
+        subject.fetch("some-id")
+      }.to raise_error(Sprig::RawRowStore::RecordNotFoundError)
+    end
+  end
+
+  describe "#cleanup" do
+    it "removes the temp directory" do
+      subject.reset
+      dir = subject.instance_variable_get(:@dir)
+
+      subject.cleanup
+
+      expect(Dir.exist?(dir)).to eq(false)
+    end
+
+    it "is safe to call when nothing has been reset yet" do
+      expect { subject.cleanup }.not_to raise_error
+    end
+  end
+
+  describe "#reset" do
+    it "cleans up a previous run's temp directory before starting fresh" do
+      subject.reset
+      subject.put("id-1", {"name" => "First"})
+      old_dir = subject.instance_variable_get(:@dir)
+
+      subject.reset
+
+      expect(Dir.exist?(old_dir)).to eq(false)
+      expect {
+        subject.fetch("id-1")
+      }.to raise_error(Sprig::RawRowStore::RecordNotFoundError)
+    end
+  end
+end

--- a/spec/lib/sprig/seed/descriptor_spec.rb
+++ b/spec/lib/sprig/seed/descriptor_spec.rb
@@ -128,6 +128,68 @@ RSpec.describe Sprig::Seed::Descriptor do
     end
   end
 
+  describe "with Sprig.configuration.spill_seed_rows_to_disk enabled" do
+    before do
+      Sprig.configure { |c| c.spill_seed_rows_to_disk = true }
+      Sprig::RawRowStore.instance.reset
+    end
+
+    it "holds the raw row in memory until #spill_to_disk! is called -- construction alone never spills" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello"}, {})
+
+      expect(descriptor.instance_variable_get(:@raw_attrs)).to eq({"sprig_id" => "1", "title" => "Hello"})
+    end
+
+    it "still produces a correct Entry when never spilled (the common, immediately-planted case)" do
+      descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello", "content" => "World"}, {})
+
+      entry = descriptor.to_entry
+      entry.save_record
+
+      expect(Post.last.title).to eq("Hello")
+      expect(Post.last.content).to eq("World")
+    end
+
+    describe "#spill_to_disk!" do
+      it "moves the raw row to RawRowStore and drops the in-memory reference" do
+        descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello"}, {})
+
+        descriptor.spill_to_disk!
+
+        expect(descriptor.instance_variable_get(:@raw_attrs)).to be_nil
+        expect(Sprig::RawRowStore.instance.fetch(descriptor.dependency_id)).to eq({"sprig_id" => "1", "title" => "Hello"})
+      end
+
+      it "still produces a correct Entry via the disk-backed store after spilling" do
+        descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello", "content" => "World"}, {})
+
+        descriptor.spill_to_disk!
+        entry = descriptor.to_entry
+        entry.save_record
+
+        expect(Post.last.title).to eq("Hello")
+        expect(Post.last.content).to eq("World")
+      end
+
+      it "keeps the same dependency_id/sprig_id consistency guarantees as the in-memory path" do
+        descriptor = described_class.new(Post, {"title" => "Hello"}, {}) # no explicit sprig_id
+        dependency_id_before = descriptor.dependency_id
+
+        descriptor.spill_to_disk!
+
+        expect(descriptor.to_entry.dependency_id).to eq(dependency_id_before)
+      end
+
+      it "drops the descriptor to at most 3 ivars, keeping it within CRuby's smallest embedded object size" do
+        descriptor = described_class.new(Post, {"sprig_id" => "1", "title" => "Hello"}, {})
+
+        descriptor.spill_to_disk!
+
+        expect(descriptor.instance_variables.size).to be <= 3
+      end
+    end
+  end
+
   describe "dependency_id / dependencies (not stored as ivars)" do
     it "does not retain dependency_id or dependencies as instance state" do
       descriptor = described_class.new(Post, {"sprig_id" => "1", "user_id" => "<%= sprig_record(Comment, 5) %>"}, {})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |c|
     Sprig.reset_configuration
     Sprig.shared_seeding = false
     Sprig::SprigRecordStore.instance.reset
+    Sprig::RawRowStore.instance.cleanup
   end
 end
 


### PR DESCRIPTION
### Ticket

#75 

Resolve Sprig's excessive memory use when loading data.

Changes in this PR:
- Optionally store records to Disk rather than in memory during large seeds

NOTE: This is Part 7 of 7 Parts.  See the [benchmark/README.md](https://github.com/vigetlabs/sprig/blob/ms/75-resolve-memory-version-3-part-7/benchmark/README.md) file for the complete explanation (it is unchanged across all stacked branches).

NOTE: Most of the content was authored by Claude Sonnet 5 under human supervision. Purely human-authored edits have their own commit.