### PR TITLE
[#75] Resolve Excessive Memory - Part 8 Matrix Validation #137

### DIFF
--- a/benchmark/matrix/README.md
+++ b/benchmark/matrix/README.md
@@ -102,27 +102,61 @@ a clear, consistent pattern (see below), and nothing here suggested a reason to 
 to change direction at 100K rows; if you want that confirmed rather than assumed, run it
 the same way.
 
+Each combination below is reported twice: **master** (`5439077`, current `master` at the
+time of this run, no memory-optimization changes) and **part-8** (this branch, with the
+full `ms/75-resolve-memory-version-3` stack applied -- deferred `Entry` construction,
+slimmed `SprigRecordStore`, streaming YAML/JSON parsing, the incremental scheduler, and
+the rest of the changes documented in [`../README.md`](../README.md)). Both runs used the
+exact same generated dataset files, the same dedicated containers, and the same
+methodology; master's runs went into separate `_master`-suffixed databases so the two
+never shared state.
+
 ### Peak RSS (MB)
 
-| | CSV | YAML | JSON |
+| | CSV (master → part-8) | YAML (master → part-8) | JSON (master → part-8) |
 |---|---:|---:|---:|
-| **Small (1K) / SQLite** | 69.1 | 66.5 | 66.9 |
-| **Small (1K) / PostgreSQL** | 70.6 | 73.9 | 73.5 |
-| **Small (1K) / MongoDB** | 106.4 | 98.6 | 106.0 |
-| **Medium (10K) / SQLite** | 133.6 | 128.3 | 136.3 |
-| **Medium (10K) / PostgreSQL** | 121.8 | 119.3 | 123.1 |
-| **Medium (10K) / MongoDB** | 393.0 | 395.3 | 388.5 |
+| **Small (1K) / SQLite** | 98.0 → 69.1 | 97.3 → 66.5 | 95.8 → 66.9 |
+| **Small (1K) / PostgreSQL** | 98.2 → 70.6 | 106.3 → 73.9 | 96.3 → 73.5 |
+| **Small (1K) / MongoDB** | 112.8 → 106.4 | 114.1 → 98.6 | 116.8 → 106.0 |
+| **Medium (10K) / SQLite** | 418.0 → 133.6 | 459.4 → 128.3 | 427.1 → 136.3 |
+| **Medium (10K) / PostgreSQL** | 425.1 → 121.8 | 446.7 → 119.3 | 411.4 → 123.1 |
+| **Medium (10K) / MongoDB** | 483.1 → 393.0 | 509.5 → 395.3 | 503.7 → 388.5 |
 
 ### Wall time (s)
 
-| | CSV | YAML | JSON |
+| | CSV (master → part-8) | YAML (master → part-8) | JSON (master → part-8) |
 |---|---:|---:|---:|
-| **Small (1K) / SQLite** | 1.41 | 1.65 | 1.35 |
-| **Small (1K) / PostgreSQL** | 2.64 | 2.90 | 2.54 |
-| **Small (1K) / MongoDB** | 8.62 | 8.21 | 7.77 |
-| **Medium (10K) / SQLite** | 9.95 | 11.02 | 9.57 |
-| **Medium (10K) / PostgreSQL** | 20.62 | 28.85 | 21.24 |
-| **Medium (10K) / MongoDB** | 80.13 | 74.57 | 64.83 |
+| **Small (1K) / SQLite** | 1.43 → 1.41 | 1.61 → 1.65 | 1.39 → 1.35 |
+| **Small (1K) / PostgreSQL** | 2.57 → 2.64 | 2.66 → 2.90 | 2.52 → 2.54 |
+| **Small (1K) / MongoDB** | 9.08 → 8.62 | 8.16 → 8.21 | 9.58 → 7.77 |
+| **Medium (10K) / SQLite** | 10.90 → 9.95 | 11.37 → 11.02 | 9.96 → 9.57 |
+| **Medium (10K) / PostgreSQL** | 21.80 → 20.62 | 23.91 → 28.85 | 20.47 → 21.24 |
+| **Medium (10K) / MongoDB** | 93.24 → 80.13 | 88.57 → 74.57 | 88.75 → 64.83 |
+
+### What the master comparison adds
+
+The memory picture is unambiguous and consistent across every one of the 18
+combinations: **part-8 uses meaningfully less peak memory than master everywhere**, and
+the reduction grows with data volume -- at medium tier it's roughly **68-73% less peak
+RSS for SQLite/PostgreSQL** (e.g. medium YAML/SQLite: 459.4MB → 128.3MB) and a smaller
+but still real **~19-23% less for MongoDB** (e.g. medium YAML/MongoDB: 509.5MB →
+395.3MB). MongoDB's smaller relative improvement lines up with the rest of this
+investigation's finding that MongoDB's own driver/BSON overhead, not Sprig's seed-side
+memory use, dominates its footprint -- Sprig-side savings have proportionally less to
+work with there.
+
+Wall time tells a different, noisier story: the two are close enough at small tier that
+run-to-run variance (see `../part-4.md`'s reinvestigation of exactly this kind of noise)
+plausibly explains which one comes out ahead on a given combination, and there's no
+consistent winner. At medium tier a real pattern does emerge for MongoDB specifically --
+part-8 is 14-27% *faster* there too (not just leaner), most plausibly because the
+incremental scheduler's cascading plant-as-ready approach keeps the single wrapping
+transaction's total work more evenly paced than master's build-the-whole-graph-then-plant
+approach, though this benchmark didn't instrument the mechanism directly to confirm that.
+For SQLite/PostgreSQL at medium tier the two are within a few percent either way -- this
+stack was never primarily a wall-time optimization, and it shows: the win it delivers is
+memory, not speed, and the wall-time numbers here are consistent with that rather than
+contradicting it.
 
 ## What this actually shows
 

--- a/benchmark/matrix/README.md
+++ b/benchmark/matrix/README.md
@@ -1,0 +1,190 @@
+# Source × storage matrix benchmark
+
+Tests every combination of seed file format and storage backend Sprig supports, using
+the same rich Customer/Tag/Project/Task/ProjectTag dataset as the rest of this benchmark
+suite (see [`../README.md`](../README.md) for the dataset's shape and the memory-focused
+investigation this one is separate from).
+
+|                | CSV | YAML | JSON |
+|----------------|:---:|:---:|:---:|
+| **SQLite**     | ✅ | ✅ | ✅ |
+| **PostgreSQL** | ✅ | ✅ | ✅ |
+| **MongoDB**    | ✅ | ✅ | ✅ |
+
+## Why this is a separate tool, not a change to the existing scripts
+
+The rest of this benchmark suite is deliberately YAML + Postgres only, to isolate memory
+effects across the `ms/75-resolve-memory-version-*` stacks without a second variable in
+play. This matrix benchmark asks a different question -- how much does the *format* and
+*storage backend* themselves matter -- so it needed its own dataset generator (one that
+can emit CSV/YAML/JSON from the same underlying rows) and its own runner (one that can
+point at any of three very different storage adapters). Rather than bolt that onto
+`generate_dataset.rb`/`run_benchmark.rb`, it lives in its own `matrix/` subfolder:
+
+- [`row_data.rb`](row_data.rb) -- the shared Faker-based row generation logic (same
+  fields, same random seeds, same relationships as the top-level `generate_*.rb`
+  scripts), returning plain Hashes rather than writing a specific format directly.
+- [`writers.rb`](writers.rb) -- serializes those rows to CSV, YAML, or JSON.
+- [`generate_matrix_dataset.rb`](generate_matrix_dataset.rb) -- CLI wrapper:
+  `ruby generate_matrix_dataset.rb <dir> <n> <yml|json|csv>`.
+- [`run_matrix_benchmark.rb`](run_matrix_benchmark.rb) -- CLI wrapper:
+  `ruby run_matrix_benchmark.rb <dataset-dir> <yml|json|csv> <sqlite|postgres|mongodb>`.
+  Same generated files work unmodified against any storage backend, since
+  `sprig_record(Klass, id).id` resolves at plant time against whichever adapter is
+  actually running -- it isn't baked into the file.
+
+## Setup
+
+**SQLite**: nothing extra -- the `sqlite3` gem is already a dev dependency. Each run
+gets a fresh file (`/tmp/sprig_benchmark_matrix.sqlite3` by default, recreated every
+run).
+
+**PostgreSQL**: reuses the same `sprig-benchmark-postgres` container as the rest of this
+suite (see `../README.md`), against a separate `sprig_benchmark_matrix` database.
+
+**MongoDB**: needs its own dedicated container, and needs `bundle` pointed at
+`gemfiles/mongoid_9.gemfile` (the repo's own Mongoid Appraisal) rather than the main
+Gemfile:
+
+```bash
+docker run -d --name sprig-benchmark-mongo -p 27018:27018 mongo:8 --replSet rs0 --port 27018
+docker exec sprig-benchmark-mongo mongosh --port 27018 --quiet --eval \
+  'rs.initiate({_id: "rs0", members: [{_id: 0, host: "localhost:27018"}]})'
+
+# See "A transaction-lifetime gotcha" below before running the medium tier.
+docker exec sprig-benchmark-mongo mongosh --port 27018 --quiet --eval \
+  'db.adminCommand({setParameter: 1, transactionLifetimeLimitSeconds: 600})'
+
+BUNDLE_GEMFILE=gemfiles/mongoid_9.gemfile bundle exec ruby benchmark/matrix/run_matrix_benchmark.rb <dir> <format> mongodb
+```
+
+This is **deliberately a separate container from `sprig-mongo-test`** (the one the spec
+suite's Mongoid Appraisals use). That container runs with a 256MB tmpfs for `/data/db`,
+sized for tiny spec fixtures -- pointing a medium-tier (10K-row) benchmark run at it
+filled the tmpfs, and WiredTiger hard-crashed the whole `mongod` process (`No space left
+on device`, fatal assert, abort) partway through a run. Discovered directly, the hard
+way, during this investigation -- not a Sprig bug, but worth recording so it doesn't
+happen again: benchmark against real disk-backed storage in its own container, never the
+spec suite's own tmpfs-limited one.
+
+## A transaction-lifetime gotcha, worth knowing about independent of this benchmark
+
+Sprig wraps an entire `sprig()` call in one transaction when the adapter supports it
+(`Sprig.configuration.wrap_in_transaction`, on by default). For Mongoid specifically,
+that means one multi-document transaction spanning however long the whole run takes.
+MongoDB's own server default caps a transaction's lifetime at
+**`transactionLifetimeLimitSeconds` = 60 seconds** -- past that, the server aborts it
+unilaterally, and every operation attempted afterward fails with
+`Mongo::Error::OperationFailure: [251:NoSuchTransaction]`, cascading into enough
+individual save failures that Sprig's own rollback logic kicks in and undoes the entire
+run.
+
+This benchmark's medium tier (10,000 rows, ~55,020 total records) takes 65-80 seconds
+against MongoDB -- right past that default. It failed silently-ish (a rollback, not a
+crash) on the first attempt, for exactly this reason, and only some formats' timing
+happened to land far enough past 60s to actually trigger it on that particular run
+(borderline timing, not deterministic). Raising the limit
+(`db.adminCommand({setParameter: 1, transactionLifetimeLimitSeconds: 600})`) fixed it
+cleanly. **This is a real, practically relevant thing to know if you're seeding a
+large dataset into MongoDB through Sprig with transactional wrapping on** -- past a
+certain data volume (and MongoDB is, per the results below, the slowest of the three
+backends tested, so it gets there sooner than SQLite/Postgres would), the default
+transaction lifetime becomes the limiting factor, not anything about Sprig's own design.
+Turning `wrap_in_transaction` off, or raising this server parameter, are both ways
+around it -- this benchmark chose the latter, to measure Sprig's real behavior rather
+than an unrelated timeout.
+
+## Results
+
+`/usr/bin/time -l` (macOS), one isolated process per combination, same methodology as
+the rest of this benchmark suite. Large tier wasn't run -- small and medium already show
+a clear, consistent pattern (see below), and nothing here suggested a reason to expect it
+to change direction at 100K rows; if you want that confirmed rather than assumed, run it
+the same way.
+
+### Peak RSS (MB)
+
+| | CSV | YAML | JSON |
+|---|---:|---:|---:|
+| **Small (1K) / SQLite** | 69.1 | 66.5 | 66.9 |
+| **Small (1K) / PostgreSQL** | 70.6 | 73.9 | 73.5 |
+| **Small (1K) / MongoDB** | 106.4 | 98.6 | 106.0 |
+| **Medium (10K) / SQLite** | 133.6 | 128.3 | 136.3 |
+| **Medium (10K) / PostgreSQL** | 121.8 | 119.3 | 123.1 |
+| **Medium (10K) / MongoDB** | 393.0 | 395.3 | 388.5 |
+
+### Wall time (s)
+
+| | CSV | YAML | JSON |
+|---|---:|---:|---:|
+| **Small (1K) / SQLite** | 1.41 | 1.65 | 1.35 |
+| **Small (1K) / PostgreSQL** | 2.64 | 2.90 | 2.54 |
+| **Small (1K) / MongoDB** | 8.62 | 8.21 | 7.77 |
+| **Medium (10K) / SQLite** | 9.95 | 11.02 | 9.57 |
+| **Medium (10K) / PostgreSQL** | 20.62 | 28.85 | 21.24 |
+| **Medium (10K) / MongoDB** | 80.13 | 74.57 | 64.83 |
+
+## What this actually shows
+
+**Storage backend dominates; source format is a rounding error by comparison.**
+Averaged across all three formats at medium tier:
+
+| Storage | Avg. wall time | Avg. peak RSS |
+|---|---:|---:|
+| SQLite | 10.2s | 132.7 MB |
+| PostgreSQL | 23.6s | 121.4 MB |
+| MongoDB | 73.2s | 392.3 MB |
+
+Averaged across all three storage backends at medium tier:
+
+| Format | Avg. wall time | Avg. peak RSS |
+|---|---:|---:|
+| JSON | 31.9s | 216.0 MB |
+| CSV | 36.9s | 216.1 MB |
+| YAML | 38.2s | 214.3 MB |
+
+The spread between the *slowest and fastest format* at medium tier is ~7s and ~2MB.
+The spread between the *slowest and fastest storage backend* is ~63s and ~271MB. Which
+file format you generate seed data in barely matters for performance; which database
+you're seeding into matters enormously. JSON edges out YAML/CSV slightly and
+consistently (likely `Oj`'s streaming C parser vs. `Psych`'s YAML parser and Ruby's own
+`CSV` library, though this benchmark didn't isolate parsing time from the rest of the
+run to confirm that specifically) -- real, but small enough that format choice should be
+driven by whatever's more convenient to author and version-control, not by performance.
+
+**MongoDB is both the slowest and the most memory-hungry backend tested, by a wide
+margin** -- roughly 3x PostgreSQL's peak RSS and 3-7x its wall time at medium tier, and
+the gap grows with scale (at small tier MongoDB is "only" ~3-6x slower and ~1.4x
+heavier; at medium tier it's ~3-7x slower and ~3x heavier). Some of this is inherent to
+the driver/BSON overhead and the transactional-wrapping cost discussed above, not
+necessarily reducible on Sprig's side; some of it might be addressable (e.g. batching --
+see the discussion in the main investigation about why that wasn't pursued for the
+memory-optimization stack specifically, though the tradeoffs for a from-scratch Mongoid
+path could differ). Not investigated further here -- this benchmark answers "how much
+does it currently differ," not "why exactly, at the mechanism level."
+
+**SQLite being both fastest and (at small tier) leanest is notable given it's the only
+backend here whose own storage engine runs in-process** -- unlike the rest of this
+benchmark suite, which deliberately excludes SQLite from its main comparison for exactly
+that reason (its in-process footprint would conflate with Sprig's own memory use). Here,
+that in-process cost is part of what's being measured on purpose, and it still comes out
+ahead of both separate-process alternatives at this data volume -- though that
+comparison would likely look different at a large enough scale that SQLite's file size
+and single-writer characteristics start to matter, which this benchmark didn't test.
+
+## Caveats
+
+- Peak RSS and wall time only (`/usr/bin/time -l`) -- this matrix doesn't carry the
+  deep `GC.stat`/`ObjectSpace`/storage-space-over-time instrumentation the main
+  memory-optimization investigation built (see `../instrumented_run.rb`). That
+  instrumentation could be pointed at `run_matrix_benchmark.rb` if a deeper mechanism
+  investigation (e.g. into *why* MongoDB is heavier, not just *that* it is) turns out to
+  be worth doing.
+- Every combination ran once, not repeated/averaged -- the main investigation found
+  real run-to-run variance worth checking with repeated trials for small effects (see
+  `../part-4.md`'s re-investigation). The differences here are large enough (multiples,
+  not single-digit percentages) that one run each is enough to see the pattern clearly,
+  but the exact numbers shouldn't be read to more precision than that.
+- MongoDB's schema here uses `Float` for what PostgreSQL/SQLite store as `decimal` --
+  Mongoid supports `BigDecimal`-backed fields too, but this benchmark didn't chase that
+  level of type parity; it's not expected to meaningfully change the memory picture.

--- a/benchmark/matrix/generate_matrix_dataset.rb
+++ b/benchmark/matrix/generate_matrix_dataset.rb
@@ -1,0 +1,38 @@
+# Generates one format's worth of the source/storage matrix benchmark's dataset --
+# the same Customer/Tag/Project/Task/ProjectTag shape, volumes, and relationships as
+# the top-level benchmark/generate_dataset.rb, serialized as CSV, YAML, or JSON
+# (chosen by output file extension) instead of being tied to YAML only. See
+# row_data.rb for the shared generation logic and writers.rb for the per-format
+# serialization.
+#
+# Usage:
+#   ruby generate_matrix_dataset.rb <output-dir> <n> <format> [tag_count] [rows_per_project]
+#
+# <format> is one of: yml, json, csv
+# Writes <output-dir>/{customers,tags,projects,tasks,project_tags}.<format>
+require "fileutils"
+require_relative "row_data"
+require_relative "writers"
+
+dir = ARGV[0]
+n = ARGV[1].to_i
+format = ARGV[2]
+tag_count = (ARGV[3] || 20).to_i
+rows_per_project = (ARGV[4] || 2.5).to_f
+
+unless dir && n > 0 && %w[yml json csv].include?(format)
+  raise "usage: generate_matrix_dataset.rb <output-dir> <n> <yml|json|csv> [tag_count] [rows_per_project]"
+end
+
+FileUtils.mkdir_p(dir)
+
+RowData = Sprig::BenchmarkMatrix::RowData
+Writers = Sprig::BenchmarkMatrix::Writers
+
+Writers.write(File.join(dir, "customers.#{format}"), RowData.customers(n))
+Writers.write(File.join(dir, "tags.#{format}"), RowData.tags(tag_count))
+Writers.write(File.join(dir, "projects.#{format}"), RowData.projects(n, n))
+Writers.write(File.join(dir, "tasks.#{format}"), RowData.tasks(n, n))
+Writers.write(File.join(dir, "project_tags.#{format}"), RowData.project_tags(n, tag_count, rows_per_project: rows_per_project))
+
+warn "generated #{dir}/{customers,tags,projects,tasks,project_tags}.#{format} for n=#{n}"

--- a/benchmark/matrix/row_data.rb
+++ b/benchmark/matrix/row_data.rb
@@ -1,0 +1,103 @@
+# Shared row-generation logic for the source/storage matrix benchmark
+# (benchmark/matrix/). Reuses the exact same fields, Faker calls, random seeds, and
+# relationship shape as the top-level benchmark/generate_*.rb scripts, so the matrix
+# benchmark tests the same rich data those do -- just re-serialized into CSV/YAML/JSON
+# by generate_matrix_dataset.rb, instead of being tied to one format.
+#
+# Each method returns a plain Array of String-keyed Hashes (one per row), with any
+# sprig_record(...) reference already rendered as the literal ERB string
+# ("<%= sprig_record(Klass, id).id %>") -- identical across every storage backend,
+# since that expression is evaluated at plant time against whatever adapter is
+# actually running, not baked into the generated file.
+require "faker"
+
+module Sprig
+  module BenchmarkMatrix
+    module RowData
+      CATEGORIES = %w[priority team type region].freeze
+      STATUSES = %w[planned active on_hold completed cancelled].freeze
+
+      def self.customers(n)
+        Faker::Config.random = Random.new(42)
+        Array.new(n) do |i|
+          {
+            "sprig_id" => i,
+            "name" => Faker::Company.name,
+            "contact_email" => Faker::Internet.email,
+            "signed_up_on" => Faker::Date.backward(days: 3650).to_s,
+            "active" => Faker::Boolean.boolean(true_ratio: 0.8),
+            "annual_revenue" => Faker::Commerce.price(range: 1_000..10_000_000),
+            "employee_count" => Faker::Number.between(from: 1, to: 50_000),
+            "notes" => Faker::Lorem.paragraph(sentence_count: 5)
+          }
+        end
+      end
+
+      def self.tags(count)
+        Faker::Config.random = Random.new(45)
+        Array.new(count) do |i|
+          {
+            "sprig_id" => i,
+            "name" => Faker::Company.buzzword,
+            "category" => CATEGORIES.sample(random: Faker::Config.random)
+          }
+        end
+      end
+
+      def self.projects(n, customer_count, link_probability: 0.7)
+        Faker::Config.random = Random.new(43)
+        rng = Faker::Config.random
+        Array.new(n) do |i|
+          row = {
+            "sprig_id" => i,
+            "title" => Faker::Commerce.product_name,
+            "status" => STATUSES.sample(random: rng),
+            "budget" => Faker::Commerce.price(range: 500..500_000),
+            "starts_on" => Faker::Date.between(from: "2016-01-01", to: "2026-01-01").to_s,
+            "billable" => Faker::Boolean.boolean,
+            "priority" => rng.rand(1..5)
+          }
+          if customer_count > 0 && rng.rand < link_probability
+            row["customer_id"] = "<%= sprig_record(Customer, #{rng.rand(0...customer_count)}).id %>"
+          end
+          row
+        end
+      end
+
+      def self.tasks(n, project_count)
+        raise "project_count must be > 0" unless project_count > 0
+
+        Faker::Config.random = Random.new(44)
+        rng = Faker::Config.random
+        Array.new(n) do |i|
+          {
+            "sprig_id" => i,
+            "title" => Faker::Lorem.sentence,
+            "description" => Faker::Lorem.paragraph,
+            "due_on" => Faker::Date.forward(days: 180).to_s,
+            "estimated_hours" => Faker::Number.decimal(l_digits: 2, r_digits: 1),
+            "completed" => Faker::Boolean.boolean,
+            "assignee_name" => Faker::Name.name,
+            "project_id" => "<%= sprig_record(Project, #{rng.rand(0...project_count)}).id %>"
+          }
+        end
+      end
+
+      def self.project_tags(project_count, tag_count, rows_per_project: 2.5)
+        raise "project_count and tag_count must both be > 0" unless project_count > 0 && tag_count > 0
+
+        Faker::Config.random = Random.new(46)
+        rng = Faker::Config.random
+        count = (project_count * rows_per_project).round
+        Array.new(count) do |i|
+          {
+            "sprig_id" => i,
+            "project_id" => "<%= sprig_record(Project, #{rng.rand(0...project_count)}).id %>",
+            "tag_id" => "<%= sprig_record(Tag, #{rng.rand(0...tag_count)}).id %>",
+            "added_on" => Faker::Date.backward(days: 730).to_s
+          }
+        end
+      end
+    end
+  end
+end

--- a/benchmark/matrix/run_matrix_benchmark.rb
+++ b/benchmark/matrix/run_matrix_benchmark.rb
@@ -1,0 +1,208 @@
+# Plants the matrix benchmark's dataset (see generate_matrix_dataset.rb) through the
+# real, public Sprig pipeline against any combination of source format and storage
+# system, so the two can be compared independently of each other -- the same
+# generated files work unmodified against every storage backend, since
+# sprig_record(Klass, id).id resolves at plant time against whichever adapter is
+# actually running, not something baked into the file.
+#
+# Usage:
+#   ruby run_matrix_benchmark.rb <dataset-dir> <yml|json|csv> <sqlite|postgres|mongodb>
+#
+# Wrap with /usr/bin/time -l (macOS) / -v (Linux) for isolated peak-RSS + wall-time
+# measurement, one combination per process, same methodology as run_benchmark.rb.
+#
+# Connection env vars:
+#   Postgres: SPRIG_BENCHMARK_PG_{HOST,PORT,USER,PASSWORD,DATABASE}, defaulting to the
+#             sprig-benchmark-postgres container on port 5433 (see benchmark/README.md).
+#   MongoDB:  SPRIG_BENCHMARK_MONGO_{HOST,PORT,DATABASE}, defaulting to port 27018 --
+#             a dedicated sprig-benchmark-mongo container, deliberately separate from
+#             the sprig-mongo-test container the spec suite uses (see
+#             benchmark/matrix/README.md's setup instructions): that one runs a small
+#             tmpfs sized for tiny spec fixtures, not benchmark-scale data, and
+#             actually ran out of space and crashed WiredTiger the first time a
+#             medium-tier (10K-row) run was pointed at it.
+#   SQLite:   SPRIG_BENCHMARK_SQLITE_PATH (defaults to a tmp file, recreated fresh
+#             each run -- SQLite's own in-process storage is deliberately part of
+#             what this matrix measures, unlike the rest of this benchmark suite,
+#             which excludes it precisely because it isn't a separate process)
+require "logger"
+require "sprig"
+
+dir = ARGV[0]
+format = ARGV[1]
+storage = ARGV[2]
+
+unless dir && %w[yml json csv].include?(format) && %w[sqlite postgres mongodb].include?(storage)
+  raise "usage: run_matrix_benchmark.rb <dataset-dir> <yml|json|csv> <sqlite|postgres|mongodb>"
+end
+
+parser = {
+  "yml" => Sprig::Parser::Yml,
+  "json" => Sprig::Parser::Json,
+  "csv" => Sprig::Parser::Csv
+}.fetch(format)
+
+Sprig.configure { |c| c.logger = Logger.new(File::NULL) }
+
+case storage
+when "sqlite", "postgres"
+  require "active_record"
+  Sprig.adapter = :active_record
+
+  ActiveRecord::Base.establish_connection(
+    if storage == "sqlite"
+      path = ENV.fetch("SPRIG_BENCHMARK_SQLITE_PATH", "/tmp/sprig_benchmark_matrix.sqlite3")
+      File.delete(path) if File.exist?(path)
+      {adapter: "sqlite3", database: path}
+    else
+      {
+        adapter: "postgresql",
+        host: ENV.fetch("SPRIG_BENCHMARK_PG_HOST", "localhost"),
+        port: ENV.fetch("SPRIG_BENCHMARK_PG_PORT", "5433").to_i,
+        user: ENV.fetch("SPRIG_BENCHMARK_PG_USER", "postgres"),
+        password: ENV.fetch("SPRIG_BENCHMARK_PG_PASSWORD", "postgres"),
+        database: ENV.fetch("SPRIG_BENCHMARK_PG_DATABASE", "sprig_benchmark_matrix")
+      }
+    end
+  )
+  ActiveRecord::Schema.verbose = false
+  unless ActiveRecord::Base.connection.table_exists?(:customers)
+    ActiveRecord::Schema.define do
+      create_table(:customers) { |t|
+        t.string :name
+        t.string :contact_email
+        t.date :signed_up_on
+        t.boolean :active
+        t.decimal :annual_revenue
+        t.integer :employee_count
+        t.text :notes
+      }
+      create_table(:tags) { |t|
+        t.string :name
+        t.string :category
+      }
+      create_table(:projects) { |t|
+        t.string :title
+        t.string :status
+        t.decimal :budget
+        t.date :starts_on
+        t.boolean :billable
+        t.integer :priority
+        t.integer :customer_id
+      }
+      create_table(:tasks) { |t|
+        t.string :title
+        t.text :description
+        t.date :due_on
+        t.decimal :estimated_hours
+        t.boolean :completed
+        t.string :assignee_name
+        t.integer :project_id
+      }
+      create_table(:project_tags) { |t|
+        t.integer :project_id
+        t.integer :tag_id
+        t.date :added_on
+      }
+    end
+  end
+  if storage == "postgres"
+    ActiveRecord::Base.connection.execute("TRUNCATE customers, tags, projects, tasks, project_tags")
+  end
+
+  class Customer < ActiveRecord::Base; end
+
+  class Tag < ActiveRecord::Base; end
+
+  class Project < ActiveRecord::Base; end
+
+  class Task < ActiveRecord::Base; end
+
+  class ProjectTag < ActiveRecord::Base; end
+when "mongodb"
+  require "mongoid"
+  Sprig.adapter = :mongoid
+
+  Mongoid.configure do |config|
+    config.clients.default = {
+      hosts: ["#{ENV.fetch("SPRIG_BENCHMARK_MONGO_HOST", "localhost")}:#{ENV.fetch("SPRIG_BENCHMARK_MONGO_PORT", "27018")}"],
+      database: ENV.fetch("SPRIG_BENCHMARK_MONGO_DATABASE", "sprig_benchmark_matrix"),
+      options: {read: {mode: :primary}}
+    }
+  end
+
+  class Customer
+    include Mongoid::Document
+
+    field :name, type: String
+    field :contact_email, type: String
+    field :signed_up_on, type: Date
+    field :active, type: Boolean
+    field :annual_revenue, type: Float
+    field :employee_count, type: Integer
+    field :notes, type: String
+  end
+
+  class Tag
+    include Mongoid::Document
+
+    field :name, type: String
+    field :category, type: String
+  end
+
+  class Project
+    include Mongoid::Document
+
+    field :title, type: String
+    field :status, type: String
+    field :budget, type: Float
+    field :starts_on, type: Date
+    field :billable, type: Boolean
+    field :priority, type: Integer
+    field :customer_id, type: BSON::ObjectId
+  end
+
+  class Task
+    include Mongoid::Document
+
+    field :title, type: String
+    field :description, type: String
+    field :due_on, type: Date
+    field :estimated_hours, type: Float
+    field :completed, type: Boolean
+    field :assignee_name, type: String
+    field :project_id, type: BSON::ObjectId
+  end
+
+  class ProjectTag
+    include Mongoid::Document
+
+    field :project_id, type: BSON::ObjectId
+    field :tag_id, type: BSON::ObjectId
+    field :added_on, type: Date
+  end
+
+  [Customer, Tag, Project, Task, ProjectTag].each { |klass| klass.delete_all }
+end
+
+class Seeder
+  include Sprig::Helpers
+end
+
+customers_path = File.join(dir, "customers.#{format}")
+tags_path = File.join(dir, "tags.#{format}")
+projects_path = File.join(dir, "projects.#{format}")
+tasks_path = File.join(dir, "tasks.#{format}")
+project_tags_path = File.join(dir, "project_tags.#{format}")
+
+directives = [
+  {class: ProjectTag, source: File.open(project_tags_path), parser: parser},
+  {class: Task, source: File.open(tasks_path), parser: parser},
+  {class: Project, source: File.open(projects_path), parser: parser},
+  {class: Tag, source: File.open(tags_path), parser: parser},
+  {class: Customer, source: File.open(customers_path), parser: parser}
+]
+
+Seeder.new.sprig(directives)
+
+warn "planted customers=#{Customer.count} tags=#{Tag.count} projects=#{Project.count} tasks=#{Task.count} project_tags=#{ProjectTag.count}"

--- a/benchmark/matrix/writers.rb
+++ b/benchmark/matrix/writers.rb
@@ -1,0 +1,51 @@
+# Serializes the row arrays from row_data.rb into the three source formats this
+# matrix benchmark compares. Each writer takes the same generic input (a plain Hash
+# of {"records" => [...], "options" => {}} -- options always empty here, since this
+# dataset never uses find_existing_by) and produces a file Sprig's own parsers can
+# read unmodified, so the exact same generated data is what every format actually
+# tests, not three independently-assembled approximations of it.
+require "csv"
+require "json"
+require "yaml"
+
+module Sprig
+  module BenchmarkMatrix
+    module Writers
+      def self.write(path, records)
+        case File.extname(path)
+        when ".yml", ".yaml"
+          write_yaml(path, records)
+        when ".json"
+          write_json(path, records)
+        when ".csv"
+          write_csv(path, records)
+        else
+          raise "Unsupported extension for #{path}"
+        end
+      end
+
+      def self.write_yaml(path, records)
+        File.write(path, YAML.dump("records" => records))
+      end
+
+      def self.write_json(path, records)
+        File.write(path, JSON.generate("records" => records))
+      end
+
+      # CSV has no nested structure, so every row needs the same column set -- the
+      # union of every key across all rows (e.g. Project rows only sometimes have
+      # customer_id). A row missing a given column is written as an empty field,
+      # which Sprig::Parser::Csv (via CSV.foreach) reads back as nil, matching the
+      # same "no customer" case the YAML/JSON versions represent by omitting the key.
+      def self.write_csv(path, records)
+        headers = records.flat_map(&:keys).uniq
+        CSV.open(path, "w") do |csv|
+          csv << headers
+          records.each do |record|
+            csv << headers.map { |h| record[h] }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Ticket

#75 

Resolve Sprig's excessive memory use when loading data.

Changes in this PR:
- Add validation scripts and results for a matrix of Source File (csv, yml, json) and storage system (sqllite, postgres, MongoDB)

NOTE: This is a pure validation of the changes made in Parts 1-7.  See the [benchmark/README.md](https://github.com/vigetlabs/sprig/blob/ms/75-resolve-memory-version-3-part-7/benchmark/README.md) file for the complete explanation (it is unchanged across all stacked branches).

NOTE: Most of the content was authored by Claude Sonnet 5 under human supervision. Purely human-authored edits have their own commit.