### PR TITLE
Allow 'Find By' to have Missing Values

### DIFF
--- a/lib/sprig/seed.rb
+++ b/lib/sprig/seed.rb
@@ -4,6 +4,7 @@ module Sprig
     autoload :AttributeCollection, "sprig/seed/attribute_collection"
     autoload :Entry, "sprig/seed/entry"
     autoload :Factory, "sprig/seed/factory"
+    autoload :NullAttribute, "sprig/seed/null_attribute"
     autoload :Record, "sprig/seed/record"
   end
 end

--- a/lib/sprig/seed/attribute_collection.rb
+++ b/lib/sprig/seed/attribute_collection.rb
@@ -10,23 +10,17 @@ module Sprig
       end
 
       def find_by_name(name)
-        attributes.detect { |attribute| attribute.name == name.to_s } || attribute_not_found(name)
+        attributes.detect { |attribute| attribute.name == name.to_s } || NullAttribute.new(name)
       end
 
       private
 
       attr_reader :attrs_hash
 
-      class AttributeNotFoundError < StandardError; end
-
       def attributes
         @attributes ||= attrs_hash.map do |name, value|
           Attribute.new(name, value)
         end
-      end
-
-      def attribute_not_found(name)
-        raise AttributeNotFoundError, "Attribute '#{name}' is not present."
       end
     end
   end

--- a/lib/sprig/seed/entry.rb
+++ b/lib/sprig/seed/entry.rb
@@ -1,6 +1,8 @@
 module Sprig
   module Seed
     class Entry
+      class UnknownAttributeError < StandardError; end
+
       attr_reader :klass
 
       def initialize(klass, attrs, options)
@@ -24,7 +26,7 @@ module Sprig
       def before_save
         # TODO: make these filters take chains like rails before_filters
         if options[:delete_existing_by]
-          klass.where(options[:delete_existing_by] => attributes.find_by_name(options[:delete_existing_by]).value).delete_all
+          klass.where(options[:delete_existing_by] => attribute_value_for(options[:delete_existing_by])).delete_all
         end
       end
 
@@ -85,9 +87,23 @@ module Sprig
       def find_existing_params
         Array(options[:find_existing_by]).inject({}) do |hash, attribute_name|
           hash.merge!(
-            {attribute_name => attributes.find_by_name(attribute_name).value}
+            {attribute_name => attribute_value_for(attribute_name)}
           )
         end
+      end
+
+      def attribute_value_for(attribute_name)
+        validate_attribute_defined!(attribute_name)
+
+        attributes.find_by_name(attribute_name).value
+      end
+
+      def validate_attribute_defined!(attribute_name)
+        return if klass.new.respond_to?(attribute_name.to_s)
+
+        raise UnknownAttributeError,
+          "'#{attribute_name}' is not a valid attribute for #{klass.name}. " \
+          "find_existing_by/delete_existing_by must reference an attribute defined on the class."
       end
     end
   end

--- a/lib/sprig/seed/null_attribute.rb
+++ b/lib/sprig/seed/null_attribute.rb
@@ -1,0 +1,19 @@
+module Sprig
+  module Seed
+    class NullAttribute
+      attr_reader :name
+
+      def initialize(name)
+        @name = name.to_s
+      end
+
+      def dependencies
+        []
+      end
+
+      def value
+        nil
+      end
+    end
+  end
+end

--- a/spec/fixtures/seeds/shared/posts_find_existing_by_missing.yml
+++ b/spec/fixtures/seeds/shared/posts_find_existing_by_missing.yml
@@ -1,7 +1,7 @@
 options:
-  find_existing_by: 'unicorn'
+  find_existing_by: ['title', 'content']
 
 records:
   - sprig_id: 1
     title: 'Existing title'
-    content: 'Updated content'
+    published: false

--- a/spec/fixtures/seeds/test/posts_find_existing_by_missing.yml
+++ b/spec/fixtures/seeds/test/posts_find_existing_by_missing.yml
@@ -1,7 +1,7 @@
 options:
-  find_existing_by: 'unicorn'
+  find_existing_by: ['title', 'content']
 
 records:
   - sprig_id: 1
     title: 'Existing title'
-    content: 'Updated content'
+    published: false

--- a/spec/lib/sprig/seed/entry_spec.rb
+++ b/spec/lib/sprig/seed/entry_spec.rb
@@ -28,4 +28,40 @@ RSpec.describe Sprig::Seed::Entry do
       end
     end
   end
+
+  describe "attributes referenced by find_existing_by/delete_existing_by" do
+    context "when the attribute isn't defined on the class" do
+      it "raises an UnknownAttributeError from find_existing_by" do
+        subject = described_class.new(Post, {title: "Hello World!", sprig_id: 1}, {find_existing_by: [:unicorn]})
+
+        expect { subject.save_record }.to raise_error(
+          Sprig::Seed::Entry::UnknownAttributeError,
+          "'unicorn' is not a valid attribute for Post. find_existing_by/delete_existing_by must reference an attribute defined on the class."
+        )
+      end
+
+      it "raises an UnknownAttributeError from delete_existing_by" do
+        subject = described_class.new(Post, {title: "Hello World!", sprig_id: 1}, {delete_existing_by: :unicorn})
+
+        expect { subject.before_save }.to raise_error(
+          Sprig::Seed::Entry::UnknownAttributeError,
+          "'unicorn' is not a valid attribute for Post. find_existing_by/delete_existing_by must reference an attribute defined on the class."
+        )
+      end
+    end
+
+    context "when the attribute is defined on the class but absent from this record" do
+      let!(:existing) do
+        Post.create(title: "Existing title", published: true, content: nil)
+      end
+
+      it "treats the missing attribute as nil instead of raising" do
+        subject = described_class.new(Post, {title: "Existing title", sprig_id: 1}, {find_existing_by: [:title, :content]})
+
+        subject.save_record
+
+        expect(subject.record.orm_record).to eq(existing)
+      end
+    end
+  end
 end

--- a/spec/sprig_shared_spec.rb
+++ b/spec/sprig_shared_spec.rb
@@ -381,24 +381,28 @@ RSpec.describe "Seeding an application with shared seeds" do
 
     context "using find_existing_by" do
       context "with a missing attribute" do
+        let!(:existing_record) do
+          Post.create(
+            title: "Existing title",
+            published: true,
+            content: nil
+          )
+        end
+
         around do |example|
           load_shared_seeds("posts_find_existing_by_missing.yml", &example)
         end
 
-        it "logs a missing attribute error" do
-          allow(Sprig.logger).to receive(:error)
+        it "assumes a nil value for the missing attribute" do
+          sprig_shared [
+            {
+              class: Post,
+              source: open("spec/fixtures/seeds/shared/posts_find_existing_by_missing.yml")
+            }
+          ]
 
-          log_should_receive(:error, with: "There was an error saving Post with sprig_id 1.")
-          log_should_receive(:error, with: "Sprig::Seed::AttributeCollection::AttributeNotFoundError: Attribute 'unicorn' is not present.")
-
-          expect {
-            sprig_shared [
-              {
-                class: Post,
-                source: open("spec/fixtures/seeds/shared/posts_find_existing_by_missing.yml")
-              }
-            ]
-          }.to_not raise_error
+          expect(Post.count).to eq(1)
+          expect(Post.first.published).to eq(false)
         end
       end
 

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -402,9 +402,10 @@ RSpec.describe "Seeding an application" do
       context "with a missing attribute" do
         let!(:existing_record) do
           Post.create(
-            :title     => "Existing title",
-            :published => true,
-            :content   => nil)
+            title: "Existing title",
+            published: true,
+            content: nil
+          )
         end
 
         around do |example|
@@ -419,8 +420,8 @@ RSpec.describe "Seeding an application" do
             }
           ]
 
-          Post.count.should == 1
-          Post.first.published.should == false
+          expect(Post.count).to eq(1)
+          expect(Post.first.published).to eq(false)
         end
       end
 

--- a/spec/sprig_spec.rb
+++ b/spec/sprig_spec.rb
@@ -400,24 +400,27 @@ RSpec.describe "Seeding an application" do
 
     context "using find_existing_by" do
       context "with a missing attribute" do
+        let!(:existing_record) do
+          Post.create(
+            :title     => "Existing title",
+            :published => true,
+            :content   => nil)
+        end
+
         around do |example|
           load_seeds("posts_find_existing_by_missing.yml", &example)
         end
 
-        it "logs a missing attribute error" do
-          allow(Sprig.logger).to receive(:error)
+        it "assumes a nil value for the missing attribute" do
+          sprig [
+            {
+              class: Post,
+              source: open("spec/fixtures/seeds/test/posts_find_existing_by_missing.yml")
+            }
+          ]
 
-          log_should_receive(:error, with: "There was an error saving Post with sprig_id 1.")
-          log_should_receive(:error, with: "Sprig::Seed::AttributeCollection::AttributeNotFoundError: Attribute 'unicorn' is not present.")
-
-          expect {
-            sprig [
-              {
-                class: Post,
-                source: open("spec/fixtures/seeds/test/posts_find_existing_by_missing.yml")
-              }
-            ]
-          }.to_not raise_error
+          Post.count.should == 1
+          Post.first.published.should == false
         end
       end
 


### PR DESCRIPTION
Allow a Sprig with `Find By` to omit null values from the data, rather than requiring an explicit null. 